### PR TITLE
🐛 fix(config): ensure custom config path is used

### DIFF
--- a/src/argoproxy/cli.py
+++ b/src/argoproxy/cli.py
@@ -126,6 +126,9 @@ def parsing_args() -> argparse.Namespace:
 
 
 def set_config_envs(args: argparse.Namespace):
+    if args.config:
+        os.environ["CONFIG_PATH"] = args.config
+
     if args.port:
         os.environ["PORT"] = str(args.port)
     if args.verbose:


### PR DESCRIPTION
- add condition to set CONFIG_PATH environment variable when user provides custom config path
- prevent fallback to searched config path when custom path is specified