### PR TITLE
🐛 fix(tool_calls): fix claude tool calls handling provided by Neil Getty

### DIFF
--- a/src/argoproxy/endpoints/chat.py
+++ b/src/argoproxy/endpoints/chat.py
@@ -412,7 +412,7 @@ async def _handle_pseudo_stream(
             total_processed += len(chunk_text)
             finish_reason = None
             if total_processed >= len(cleaned_text):
-                finish_reason = "stop"
+                finish_reason = "tool_calls" if tool_calls else "stop"
             if asyncio.iscoroutinefunction(openai_compat_fn):
                 chunk_json = await openai_compat_fn(
                     chunk_text,


### PR DESCRIPTION
- set finish_reason to "tool_calls" when tool calls are present in pseudo stream
- add robust parsing for leaked tool calls in claude text content using ast.literal_eval
- implement balanced dictionary detection to extract tool calls from text
- clean up text content by removing leaked tool call strings