### PR TITLE
✨ feat(app): increase client_max_size to 100MB for handling large image payloads

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -231,7 +231,10 @@ async def get_version(request: web.Request):
 
 def create_app():
     """Factory function to create a new application instance"""
-    app = web.Application()
+    # Set client_max_size to 100MB to handle large image payloads from remote clients
+    # Users may send images larger than the gateway's 20MB limit; argo-proxy will
+    # compress them before forwarding. Default aiohttp limit is 1MB which is too small.
+    app = web.Application(client_max_size=100 * 1024 * 1024)
     app.on_startup.append(prepare_app)
     app.on_shutdown.append(cleanup_app)
 


### PR DESCRIPTION
## Summary

This PR increases the aiohttp client_max_size limit to handle large image payloads from remote clients.

### Changes

- Set `client_max_size` to 100MB in `web.Application` to support large image uploads
- argo-proxy will compress images before forwarding to gateway with 20MB limit
- Default aiohttp limit of 1MB is insufficient for user image payloads

### Background

When users send large images (e.g., high-resolution photos), the default aiohttp limit of 1MB causes request failures. This change allows argo-proxy to accept larger payloads, which will then be compressed before forwarding to the upstream gateway that has a 20MB limit.