### PR TITLE
fix: sync dev proxy route mapping with Argo Gateway API

### DIFF
--- a/src/argoproxy/endpoints/dev_proxy.py
+++ b/src/argoproxy/endpoints/dev_proxy.py
@@ -162,11 +162,11 @@ def register_dev_routes(app: web.Application, config) -> None:
 
     # Route definitions: (local_prefix, upstream_base)
     route_map = [
-        ("/chat/", f"{base_url}/api/v1/resource/chat/"),
-        ("/stream/", f"{base_url}/api/v1/resource/streamchat/"),
-        ("/embed/", f"{base_url}/api/v1/resource/embed/"),
-        ("/message/", f"{base_url}/message/"),  # Anthropic compatible
-        ("/v1/", f"{base_url}/v1/"),  # OpenAI compatible
+        ("/api/", f"{base_url}/api/"),  # Gateway legacy API paths
+        ("/chat/", f"{base_url}/api/v1/resource/chat/"),  # Shortcut
+        ("/stream/", f"{base_url}/api/v1/resource/streamchat/"),  # Shortcut
+        ("/embed/", f"{base_url}/api/v1/resource/embed/"),  # Shortcut
+        ("/v1/", f"{base_url}/v1/"),  # OpenAI/Anthropic compatible
     ]
 
     for local_prefix, upstream_base in route_map:


### PR DESCRIPTION
## Problem

Commit `72ed27a` simplified `_argo_dev_base` from `https://apps-dev.inside.anl.gov/argoapi/api/v1/` to `https://apps-dev.inside.anl.gov/argoapi`, but the route mapping in `dev_proxy.py` was not updated accordingly, causing the dev proxy exposed paths to be inconsistent with the Gateway.

## Fix

- **Add `/api/` prefix route**: Map `/api/v1/*` to `{base_url}/api/v1/*`, enabling Gateway legacy API paths (e.g., `/api/v1/models/`, `/api/v1/resource/chat/`) to be accessible through the dev proxy
- **Remove `/message/` mapping**: Gateway returns 404 for `/message/`, and `/v1/messages` is already covered by the `/v1/` route
- Retain `/chat/`, `/stream/`, `/embed/` as shortcuts
- Retain `/v1/` for OpenAI/Anthropic compatible endpoints

## Before/After Comparison

| Path | Gateway | Before Fix (dev proxy) | After Fix (dev proxy) |
|---|---|---|---|
| `/api/v1/models/` | 200 ✓ | 404 ✗ | 200 ✓ |
| `/api/v1/resource/chat/` | 200 ✓ | 404 ✗ | 200 ✓ |
| `/v1/models` | 200 ✓ | 200 ✓ | 200 ✓ |
| `/v1/messages` | 200 ✓ | 200 ✓ | 200 ✓ |
| `/message/` | 404 ✗ | Mapped but also 404 | No longer mapped |