### PR TITLE
fix: use correct input format for tool validation on native Anthropic endpoint

### DIFF
--- a/src/argoproxy/endpoints/native_anthropic.py
+++ b/src/argoproxy/endpoints/native_anthropic.py
@@ -81,10 +81,10 @@ async def proxy_native_anthropic_request(
             model_family = determine_model_family(data.get("model", "claude"))
             if model_family in ["google", "unknown"]:
                 # Use prompting based tool handling for Google and unknown models
-                data = handle_tools(data, native_tools=False)
+                data = handle_tools(data, native_tools=False, input_format="anthropic")
             else:
                 # Use native tool handling for OpenAI and Anthropic models
-                data = handle_tools(data, native_tools=config.native_tools)
+                data = handle_tools(data, native_tools=config.native_tools, input_format="anthropic")
 
         # Apply username passthrough - Anthropic uses metadata.user_id
         _apply_user_identification(data, request, config)


### PR DESCRIPTION
## Summary
- Add `input_format` parameter to `handle_tools`/`handle_tools_native` and pass `"anthropic"` from the native Anthropic endpoint so tools are parsed with the correct schema instead of failing OpenAI `ChatCompletionToolParam` validation.
- Allow `ToolChoice._handle_anthropic` to accept string values (`"auto"`, `"any"`, `"none"`) in addition to dicts.
- Short-circuit `handle_tools_native` when input format already matches the target model type, avoiding needless re-serialization.

## Test plan
- [ ] Send a request with tools via `/v1/messages` to an Anthropic model — tools should pass through without conversion or error
- [ ] Send a request with `tool_choice` as string (`"auto"`) via `/v1/messages` — should not crash
- [ ] Send a request without `tool_choice` via `/v1/messages` — should not inject a default `tool_choice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)