### PR TITLE
Fix: honor verbose setting from config.yaml

### DIFF
--- a/src/argoproxy/cli.py
+++ b/src/argoproxy/cli.py
@@ -432,8 +432,19 @@ def main():
         config_path = Path(args.config) if args.config else None
         if config_path is None and hasattr(config_instance, "_config_path"):
             config_path = config_instance._config_path
+
+        # CLI --verbose/--quiet explicitly override config.yaml's verbose setting.
+        # If neither is specified, fall back to config.yaml's verbose value.
+        if args.verbose:
+            effective_verbose = True
+        elif args.quiet:
+            effective_verbose = False
+        else:
+            effective_verbose = config_instance.verbose if config_instance else False
+
         setup_logging(
-            verbose=args.verbose, config_path=str(config_path) if config_path else None
+            verbose=effective_verbose,
+            config_path=str(config_path) if config_path else None,
         )
 
         # Update attack logger with actual config path


### PR DESCRIPTION
Fixes #63

Previously, `setup_logging()` in `cli.py` always used `args.verbose` (CLI flag, default `False`), ignoring the `verbose` setting in `config.yaml`. This meant that even with `verbose: true` in the config file, the logging handler level remained at INFO, silently discarding DEBUG-level detailed logs.

**Fix**: After config is loaded, determine the effective verbose value with the following priority:
1. CLI `--verbose` flag → force enable verbose (DEBUG level)
2. CLI `--quiet` flag → force disable verbose (INFO level)  
3. Neither specified → fall back to `config.verbose` from config.yaml

**Tested scenarios**:
- `verbose: true` in config, no CLI flag → DEBUG logs visible ✅
- `verbose: false` in config, no CLI flag → only INFO logs ✅
- `verbose: true` in config, `--quiet` CLI flag → only INFO logs (CLI overrides) ✅