### PR TITLE
fix: handle JSON-style boolean/null literals in leaked tool parser

### DIFF
--- a/src/argoproxy/tool_calls/leaked_tool_parser.py
+++ b/src/argoproxy/tool_calls/leaked_tool_parser.py
@@ -51,6 +51,21 @@ class LeakedToolParser:
         pass
 
     @staticmethod
+    def _fix_json_literals(s: str) -> str:
+        """Replace JSON-style literals with Python equivalents.
+
+        Claude models sometimes emit ``false``, ``true``, or ``null`` (JSON
+        style) instead of Python's ``False``, ``True``, ``None`` in leaked
+        tool-call dicts.  This helper uses word-boundary-aware substitution
+        so it won't corrupt values that merely *contain* the substring (e.g.
+        ``'falsehood'``).
+        """
+        s = re.sub(r"\bfalse\b", "False", s)
+        s = re.sub(r"\btrue\b", "True", s)
+        s = re.sub(r"\bnull\b", "None", s)
+        return s
+
+    @staticmethod
     def _try_parse_candidate(candidate_str: str) -> Optional[Dict[str, Any]]:
         """
         Try to parse a candidate string as a Python dict literal.
@@ -65,6 +80,8 @@ class LeakedToolParser:
             3. Combination of strategies 1 + 2.
             4. Fix extra closing braces before ``'name'``/``'type'`` keys.
             5. Combination of strategies 1 + 4.
+            6. Fix JSON-style literals (``false``/``true``/``null``).
+            7–11. Combinations of strategy 6 with strategies 1–5.
 
         Args:
             candidate_str: The raw candidate string to parse.
@@ -96,6 +113,23 @@ class LeakedToolParser:
         )
 
         for repaired_str in (s1, s2, s3, s4, s5):
+            try:
+                result = ast.literal_eval(repaired_str)
+                if isinstance(result, dict) and "id" in result and "name" in result:
+                    return result
+            except (ValueError, SyntaxError):
+                continue
+
+        # Strategy 6: Fix JSON-style literals (false/true/null → False/True/None)
+        s6 = LeakedToolParser._fix_json_literals(candidate_str)
+        # Also combine with all previous strategies
+        s7 = LeakedToolParser._fix_json_literals(s1)
+        s8 = LeakedToolParser._fix_json_literals(s2)
+        s9 = LeakedToolParser._fix_json_literals(s3)
+        s10 = LeakedToolParser._fix_json_literals(s4)
+        s11 = LeakedToolParser._fix_json_literals(s5)
+
+        for repaired_str in (s6, s7, s8, s9, s10, s11):
             try:
                 result = ast.literal_eval(repaired_str)
                 if isinstance(result, dict) and "id" in result and "name" in result:

--- a/test/test_leaked_tool_parser.py
+++ b/test/test_leaked_tool_parser.py
@@ -53,6 +53,46 @@ class TestLeakedToolParser:
         assert result is not None
         assert result["name"] == "test"
 
+    def test_try_parse_candidate_json_false(self):
+        """Test repair of JSON-style 'false' literal."""
+        text = "{'id': 'toolu_123', 'name': 'test', 'input': {'run': false}, 'cache_control': None}"
+        result = LeakedToolParser._try_parse_candidate(text)
+        assert result is not None
+        assert result["input"]["run"] is False
+
+    def test_try_parse_candidate_json_true(self):
+        """Test repair of JSON-style 'true' literal."""
+        text = "{'id': 'toolu_123', 'name': 'test', 'input': {'enabled': true}}"
+        result = LeakedToolParser._try_parse_candidate(text)
+        assert result is not None
+        assert result["input"]["enabled"] is True
+
+    def test_try_parse_candidate_json_null(self):
+        """Test repair of JSON-style 'null' literal."""
+        text = "{'id': 'toolu_123', 'name': 'test', 'cache_control': null}"
+        result = LeakedToolParser._try_parse_candidate(text)
+        assert result is not None
+        assert result["cache_control"] is None
+
+    def test_try_parse_candidate_json_literals_in_string_values(self):
+        """Test that strings containing 'false'/'true'/'null' as words parse correctly.
+
+        When the dict is already valid Python (no bare JSON booleans), the
+        direct ast.literal_eval succeeds and no repair runs, preserving the
+        original string values unchanged.
+        """
+        text = "{'id': 'toolu_123', 'name': 'test', 'input': {'text': 'this is not false or true or null'}}"
+        result = LeakedToolParser._try_parse_candidate(text)
+        assert result is not None
+        assert result["input"]["text"] == "this is not false or true or null"
+
+    def test_try_parse_candidate_json_false_combined_with_newline_repair(self):
+        """Test JSON literal repair combined with newline repair."""
+        text = "{'id': 'toolu_123', 'name': 'test', 'input': {'text': 'line1\\nline2'}, 'run_in_background': false}"
+        result = LeakedToolParser._try_parse_candidate(text)
+        assert result is not None
+        assert result["run_in_background"] is False
+
     def test_try_parse_candidate_invalid_string(self):
         """Test that completely invalid strings return None."""
         text = "this is not a dict at all"
@@ -263,3 +303,18 @@ class TestExtractLeakedToolCalls:
 
         assert len(tools) == 1
         assert cleaned == "BeforeAfter"
+
+    def test_extract_tool_with_json_false_literal(self):
+        """Test extracting a leaked tool that uses JSON 'false' instead of Python 'False'."""
+        text = (
+            "Let me delegate this:"
+            "{'id': 'toolu_vrtx_01RW7dSW3M47z5mPAf6cSUuU', "
+            "'input': {'category': 'deep', 'run_in_background': false}, "
+            "'name': 'task', 'type': 'tool_use', 'cache_control': None}"
+        )
+        tools, cleaned = extract_leaked_tool_calls(text)
+
+        assert len(tools) == 1
+        assert tools[0]["name"] == "task"
+        assert tools[0]["input"]["run_in_background"] is False
+        assert cleaned == "Let me delegate this:"


### PR DESCRIPTION
## Summary
- Add repair strategy for JSON-style `false`/`true`/`null` literals in leaked tool call parsing
- Claude models sometimes emit JSON booleans instead of Python's `False`/`True`/`None`, causing `ast.literal_eval` to fail
- New strategy uses word-boundary-aware regex to avoid corrupting string values, and is combined with all existing repair strategies
- 
## Root Cause
The leaked tool parser uses `ast.literal_eval` which only accepts Python literals. When a leaked tool dict contains `'run_in_background': false` (JSON) instead of `'run_in_background': False` (Python), all candidate endings fail — producing the `Failed to parse leaked tool string after trying N candidate endings` warning.