### PR TITLE
Replace loguru with stdlib logging in example files

### DIFF
--- a/examples/openai/sdk_based/openai_calculator_example_chat_api.py
+++ b/examples/openai/sdk_based/openai_calculator_example_chat_api.py
@@ -1,11 +1,13 @@
+import logging
 import os
 
 from dotenv import load_dotenv
-from loguru import logger
 from openai import OpenAI
 
 from toolregistry import ToolRegistry
 from toolregistry.hub.calculator import Calculator
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables from .env file
 load_dotenv()

--- a/examples/openai/sdk_based/openai_calculator_example_response_api.py
+++ b/examples/openai/sdk_based/openai_calculator_example_response_api.py
@@ -1,10 +1,12 @@
+import logging
 import os
 
 from dotenv import load_dotenv
-from loguru import logger
 from openai import OpenAI
 from toolregistry import ToolRegistry
 from toolregistry.hub.calculator import Calculator
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables from .env file
 load_dotenv()
@@ -41,7 +43,7 @@ def handle_tool_calls_response(response, messages):
         for each in response.output:
             if each.type == "function_call":
                 tool_calls.append(each)
-        logger.warning("Tool calls:", tool_calls)
+        logger.warning(f"Tool calls: {tool_calls}")
 
         # Execute tool calls
         tool_responses = tool_registry.execute_tool_calls(tool_calls)


### PR DESCRIPTION
## Summary
- Replace `from loguru import logger` with stdlib `logging` in 2 example files
- Fix positional-arg `logger.warning("Tool calls:", tool_calls)` call to use f-string for stdlib compatibility
- Aligns examples with the rest of the project, which already migrated to stdlib logging

Fixes #94

## Test plan
- [ ] Verify both example scripts still run correctly with the OpenAI API
- [ ] Confirm no remaining `loguru` imports exist in the project