### PR TITLE
feat: configurable Anthropic non-streaming stream mode

### DIFF
--- a/src/argoproxy/cli/handlers.py
+++ b/src/argoproxy/cli/handlers.py
@@ -47,6 +47,8 @@ def set_config_envs(args: argparse.Namespace):
         os.environ["ENABLE_LEAKED_TOOL_FIX"] = str(True)
     if args.dev:
         os.environ["DEV_MODE"] = str(True)
+    if args.anthropic_stream_mode:
+        os.environ["ANTHROPIC_STREAM_MODE"] = args.anthropic_stream_mode
 
 
 def handle_serve(args: argparse.Namespace):
@@ -327,59 +329,75 @@ def _handle_env(env_name: str | None = None, config_path: str | None = None):
 # ---------------------------------------------------------------------------
 
 
-def _collect_leaked_logs(config_path: str | None = None):
-    """Collect all leaked tool call logs into a tar.gz archive.
+# Known diagnostic log categories: (dir_name, file_glob_patterns)
+_DIAGNOSTIC_LOG_TYPES: dict[str, tuple[str, list[str]]] = {
+    "leaked-tool": (
+        "leaked_tool_calls",
+        ["leaked_tool_*.json", "leaked_tool_*.json.gz"],
+    ),
+    "stream-retry": ("stream_retry_dumps", ["retry_*.json", "retry_*.json.gz"]),
+}
+
+
+def _collect_diagnostic_logs(
+    config_path: str | None = None, log_type: str = "all"
+) -> None:
+    """Collect diagnostic logs into a tar.gz archive.
 
     Args:
         config_path: Optional explicit path to the config file.
+        log_type: Type of logs to collect. One of the keys in
+            ``_DIAGNOSTIC_LOG_TYPES`` or ``"all"``.
     """
     import tarfile
     from datetime import datetime
 
     from ..config import load_config
 
-    config_data, actual_config_path = load_config(config_path, verbose=False)
+    _, actual_config_path = load_config(config_path, verbose=False)
+    base_dir = actual_config_path.parent if actual_config_path else Path.cwd()
 
-    if actual_config_path:
-        log_dir = actual_config_path.parent / "leaked_tool_calls"
+    # Determine which log types to collect
+    if log_type == "all":
+        types_to_collect = list(_DIAGNOSTIC_LOG_TYPES.keys())
     else:
-        log_dir = Path.cwd() / "leaked_tool_calls"
+        types_to_collect = [log_type]
 
-    if not log_dir.exists():
-        log_error(f"Log directory not found: {log_dir}", context="cli")
-        log_info("No leaked tool call logs to collect.", context="cli")
-        return
+    # Gather files across all requested types
+    all_files: list[tuple[Path, str]] = []  # (file_path, arcname)
+    for type_key in types_to_collect:
+        dir_name, patterns = _DIAGNOSTIC_LOG_TYPES[type_key]
+        log_dir = base_dir / dir_name
+        if not log_dir.exists():
+            continue
+        for pattern in patterns:
+            for f in log_dir.glob(pattern):
+                # Use subdir/filename as arcname to preserve category
+                all_files.append((f, f"{dir_name}/{f.name}"))
 
-    json_files = list(log_dir.glob("leaked_tool_*.json"))
-    gz_files = list(log_dir.glob("leaked_tool_*.json.gz"))
-
-    if not json_files and not gz_files:
-        log_info(f"No leaked tool call logs found in {log_dir}", context="cli")
+    if not all_files:
+        label = log_type if log_type != "all" else "diagnostic"
+        log_info(f"No {label} logs found.", context="cli")
         return
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    archive_name = f"leaked_tool_logs_{timestamp}.tar.gz"
+    archive_name = f"diagnostic_logs_{log_type}_{timestamp}.tar.gz"
     archive_path = Path.cwd() / archive_name
 
-    log_info(
-        f"Collecting {len(json_files)} JSON and {len(gz_files)} compressed logs...",
-        context="cli",
-    )
+    log_info(f"Collecting {len(all_files)} log files...", context="cli")
     log_info(f"Creating archive: {archive_path}", context="cli")
 
     try:
         with tarfile.open(archive_path, "w:gz") as tar:
-            for json_file in json_files:
-                tar.add(json_file, arcname=json_file.name)
-            for gz_file in gz_files:
-                tar.add(gz_file, arcname=gz_file.name)
+            for file_path, arcname in all_files:
+                tar.add(file_path, arcname=arcname)
 
         archive_size = archive_path.stat().st_size
         log_info("=" * 80, context="cli")
         log_info("Archive created successfully!", context="cli")
         log_info(f"   Location: {archive_path}", context="cli")
         log_info(f"   Size: {archive_size / 1024 / 1024:.2f} MB", context="cli")
-        log_info(f"   Files: {len(json_files) + len(gz_files)} logs", context="cli")
+        log_info(f"   Files: {len(all_files)} logs", context="cli")
         log_info("=" * 80, context="cli")
         log_info("", context="cli")
         log_info("Please send this archive to:", context="cli")
@@ -408,7 +426,7 @@ def handle_logs(args: argparse.Namespace):
     config_path = getattr(args, "config", None)
 
     if args.logs_action == "collect":
-        _collect_leaked_logs(config_path)
+        _collect_diagnostic_logs(config_path, log_type=getattr(args, "type", "all"))
 
 
 # ---------------------------------------------------------------------------

--- a/src/argoproxy/cli/parser.py
+++ b/src/argoproxy/cli/parser.py
@@ -87,6 +87,18 @@ def _add_serve_arguments(parser: argparse.ArgumentParser) -> None:
         help="[Legacy only] Enable AST-based leaked tool call detection and fixing",
     )
     parser.add_argument(
+        "--anthropic-stream-mode",
+        type=str,
+        choices=["force", "retry", "passthrough"],
+        default=None,
+        help=(
+            "How to handle non-streaming requests to Anthropic upstream.\n"
+            "  force:       Always force streaming, aggregate back (default)\n"
+            "  retry:       Try non-streaming first, retry with streaming on error\n"
+            "  passthrough: Never force streaming, pass through as-is"
+        ),
+    )
+    parser.add_argument(
         "--dev",
         action="store_true",
         default=False,
@@ -170,10 +182,23 @@ def _add_logs_subparsers(parser: argparse.ArgumentParser) -> None:
     sub = parser.add_subparsers(dest="logs_action", metavar="action")
 
     collect_parser = sub.add_parser(
-        "collect", help="Collect leaked tool call logs into a tar.gz archive"
+        "collect", help="Collect diagnostic logs into a tar.gz archive"
     )
     collect_parser.add_argument(
         "config", nargs="?", default=None, help="Config file path"
+    )
+    collect_parser.add_argument(
+        "--type",
+        "-t",
+        type=str,
+        choices=["leaked-tool", "stream-retry", "all"],
+        default="all",
+        help=(
+            "Type of diagnostic logs to collect (default: all)\n"
+            "  leaked-tool:  Leaked tool call logs\n"
+            "  stream-retry: Anthropic stream retry request dumps\n"
+            "  all:          All diagnostic logs"
+        ),
     )
 
 

--- a/src/argoproxy/config/io.py
+++ b/src/argoproxy/config/io.py
@@ -34,6 +34,7 @@ def _format_config_yaml(data: dict) -> str:
                 "native_openai_base_url",
                 "native_anthropic_base_url",
                 "use_legacy_argo",
+                "anthropic_stream_mode",
             ],
         ),
         (
@@ -157,6 +158,18 @@ def _apply_env_overrides(config_data: ArgoConfig) -> ArgoConfig:
 
     if env_skip_url_validation := os.getenv("SKIP_URL_VALIDATION"):
         config_data._skip_url_validation = str_to_bool(env_skip_url_validation)
+
+    if env_anthropic_stream_mode := os.getenv("ANTHROPIC_STREAM_MODE"):
+        mode = env_anthropic_stream_mode.lower().strip()
+        valid_modes = ("force", "retry", "passthrough")
+        if mode in valid_modes:
+            config_data._anthropic_stream_mode = mode
+        else:
+            log_warning(
+                f"Invalid ANTHROPIC_STREAM_MODE '{env_anthropic_stream_mode}', "
+                f"expected one of {valid_modes}. Using default 'force'.",
+                context="config",
+            )
 
     return config_data
 

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -61,6 +61,9 @@ class ArgoConfig:
     _enable_leaked_tool_fix: bool = False
     _dev_mode: bool = False
 
+    # Anthropic non-streaming request handling mode
+    _anthropic_stream_mode: str = "force"  # "force", "retry", or "passthrough"
+
     # Validation and resolver settings
     _skip_url_validation: bool = False
     _user_validated: bool = False  # Set after upstream user validation passes
@@ -181,6 +184,23 @@ class ArgoConfig:
         """Check if dev (pure reverse proxy) mode is enabled."""
         return self._dev_mode
 
+    @property
+    def anthropic_stream_mode(self) -> str:
+        """Anthropic non-streaming request handling mode.
+
+        Returns:
+            One of ``"force"``, ``"retry"``, or ``"passthrough"``.
+
+            - ``force``: Always force streaming upstream, aggregate back (default).
+            - ``retry``: Try non-streaming first, retry with streaming on
+              Anthropic's "streaming is required" bounce-back error.
+            - ``passthrough``: Never force streaming, pass through as-is.
+        """
+        valid = ("force", "retry", "passthrough")
+        if self._anthropic_stream_mode in valid:
+            return self._anthropic_stream_mode
+        return "force"
+
     @classmethod
     def from_dict(cls, config_dict: dict):
         """Create ArgoConfig instance from a dictionary."""
@@ -195,6 +215,7 @@ class ArgoConfig:
             "native_anthropic_base_url": "_native_anthropic_base_url",
             "use_legacy_argo": "_use_legacy_argo",
             "skip_url_validation": "_skip_url_validation",
+            "anthropic_stream_mode": "_anthropic_stream_mode",
         }
         valid_fields = {
             k: v for k, v in config_dict.items() if k in cls.__annotations__
@@ -226,6 +247,8 @@ class ArgoConfig:
             serialized["use_legacy_argo"] = True
         if self._skip_url_validation:
             serialized["skip_url_validation"] = True
+        if self._anthropic_stream_mode != "force":
+            serialized["anthropic_stream_mode"] = self._anthropic_stream_mode
 
         # Persist native URLs only when explicitly overridden (differ from
         # the values that would be derived from argo_base_url)

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -10,6 +10,7 @@ When source and target formats match, requests pass through without conversion.
 from __future__ import annotations
 
 import json
+import os
 import time
 import traceback
 from collections.abc import Callable
@@ -132,6 +133,81 @@ def _error_response(
         body = {"error": {"message": message}}
 
     return web.json_response(body, status=status_code)
+
+
+def _is_anthropic_stream_required_error(status_code: int, error_text: str) -> bool:
+    """Detect Anthropic's 'streaming is required' bounce-back error.
+
+    This error (HTTP 500) is returned immediately when Anthropic determines
+    the operation may exceed 10 minutes.
+    """
+    if status_code != 500:
+        return False
+    return "streaming is required" in error_text.lower()
+
+
+def _dump_stream_retry_request(
+    request_body: dict[str, Any],
+    error_status: int,
+    error_text: str,
+    upstream_url: str,
+) -> None:
+    """Dump request details when retry mode triggers a forced-streaming retry.
+
+    Saves a JSON file to ``<config_dir>/stream_retry_dumps/`` for diagnostics.
+    """
+    import gzip
+    from datetime import datetime
+    from pathlib import Path
+
+    try:
+        config_path = os.environ.get("CONFIG_PATH")
+        if config_path:
+            log_dir = Path(config_path).parent / "stream_retry_dumps"
+        else:
+            log_dir = Path.cwd() / "stream_retry_dumps"
+
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Auto-compress when directory exceeds 50MB
+        dir_size = sum(f.stat().st_size for f in log_dir.iterdir() if f.is_file())
+        if dir_size > 50 * 1024 * 1024:
+            log_warning(
+                f"Stream retry dump directory ({dir_size / 1024 / 1024:.2f}MB) "
+                "exceeds 50MB, compressing logs...",
+                context="dispatch",
+            )
+            for json_file in log_dir.glob("retry_*.json"):
+                try:
+                    gz_path = json_file.with_suffix(".json.gz")
+                    with (
+                        open(json_file, "rb") as f_in,
+                        gzip.open(gz_path, "wb", compresslevel=9) as f_out,
+                    ):
+                        f_out.write(f_in.read())
+                    json_file.unlink()
+                except Exception as exc:
+                    log_error(
+                        f"Failed to compress {json_file}: {exc}", context="dispatch"
+                    )
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        log_file = log_dir / f"retry_{timestamp}.json"
+
+        entry = {
+            "timestamp": datetime.now().isoformat(),
+            "upstream_url": upstream_url,
+            "error_status": error_status,
+            "error_text": error_text,
+            "request_body": request_body,
+        }
+
+        with open(log_file, "w", encoding="utf-8") as f:
+            json.dump(entry, f, indent=2, ensure_ascii=False)
+
+        log_info(f"Dumped retry request to: {log_file}", context="dispatch")
+    except Exception as exc:
+        log_error(f"Failed to dump retry request: {exc}", context="dispatch")
 
 
 # ---------------------------------------------------------------------------
@@ -618,6 +694,69 @@ async def _passthrough_buffered_streaming(
         return web.json_response(response_data)
 
 
+async def _passthrough_with_retry(
+    session: aiohttp.ClientSession,
+    upstream_url: str,
+    headers: dict[str, str],
+    data: dict[str, Any],
+    source_provider: ProviderType = "anthropic",
+) -> web.Response:
+    """Try non-streaming passthrough, retry with forced streaming on bounce-back.
+
+    Used in ``retry`` mode when target is Anthropic and client sends
+    non-streaming.  First attempts a normal non-streaming request.  If
+    Anthropic returns the "streaming is required" error (HTTP 500), dumps
+    the request for diagnostics and retries via
+    ``_passthrough_buffered_streaming``.
+    """
+    should_retry = False
+
+    async with session.post(upstream_url, headers=headers, json=data) as upstream_resp:
+        response_text = await upstream_resp.text()
+        status = upstream_resp.status
+
+        if _is_anthropic_stream_required_error(status, response_text):
+            log_info(
+                "Anthropic returned 'streaming required' error, "
+                "retrying with forced streaming (retry mode)",
+                context="dispatch",
+            )
+            _dump_stream_retry_request(data, status, response_text, upstream_url)
+            should_retry = True
+        else:
+            # Normal response handling (mirrors _passthrough_non_streaming)
+            if contains_argo_auth_warning(response_text):
+                log_error(ARGO_AUTH_ERROR_MESSAGE, context="dispatch")
+                return _error_response(source_provider, 403, ARGO_AUTH_ERROR_MESSAGE)
+
+            try:
+                response_data = json.loads(response_text)
+            except (json.JSONDecodeError, ValueError):
+                return web.Response(
+                    text=response_text,
+                    status=status,
+                    content_type=upstream_resp.content_type or "text/plain",
+                )
+
+            upstream_fmt = "anthropic" if "/messages" in upstream_url else "openai"
+            if check_response_for_argo_warning(response_data, upstream_fmt):
+                log_error(ARGO_AUTH_ERROR_MESSAGE, context="dispatch")
+                return _error_response(source_provider, 403, ARGO_AUTH_ERROR_MESSAGE)
+
+            return web.json_response(
+                response_data,
+                status=status,
+                content_type="application/json",
+            )
+
+    if should_retry:
+        return await _passthrough_buffered_streaming(
+            session, upstream_url, headers, data, source_provider
+        )
+
+    return _error_response(source_provider, 500, "Unexpected retry flow error")
+
+
 # ---------------------------------------------------------------------------
 # Cross-format conversion handlers
 # ---------------------------------------------------------------------------
@@ -826,6 +965,51 @@ async def _convert_buffered_streaming(
 
     except aiohttp.ClientError as exc:
         return _error_response(source_provider, 502, f"Upstream request failed: {exc}")
+
+
+async def _convert_with_retry(
+    session: aiohttp.ClientSession,
+    upstream_url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    source_provider: ProviderType,
+    target_provider: ProviderType,
+    config: ArgoConfig,
+) -> web.Response:
+    """Try non-streaming cross-format conversion, retry with buffered streaming.
+
+    Used in ``retry`` mode for cross-format requests targeting Anthropic.
+    Calls ``_convert_non_streaming`` first; if the upstream returns the
+    "streaming is required" bounce-back, dumps the request and retries
+    via ``_convert_buffered_streaming``.
+    """
+    result = await _convert_non_streaming(
+        session, upstream_url, headers, body, source_provider, target_provider, config
+    )
+
+    if result.status == 500 and result.body:
+        try:
+            body_text = result.body.decode("utf-8")
+            if _is_anthropic_stream_required_error(500, body_text):
+                log_info(
+                    "Anthropic returned 'streaming required' error, "
+                    "retrying with forced streaming (retry mode, cross-format)",
+                    context="dispatch",
+                )
+                _dump_stream_retry_request(body, 500, body_text, upstream_url)
+                return await _convert_buffered_streaming(
+                    session,
+                    upstream_url,
+                    headers,
+                    body,
+                    source_provider,
+                    target_provider,
+                    config,
+                )
+        except (UnicodeDecodeError, AttributeError):
+            pass
+
+    return result
 
 
 async def _convert_streaming(
@@ -1154,13 +1338,21 @@ async def proxy_request(
                     target_provider,
                     source_provider,
                 )
-            # Force streaming for Anthropic non-streaming requests to avoid
-            # the "Streaming is required for operations that may take longer
-            # than 10 minutes" error from the Anthropic API.
+            # Handle Anthropic non-streaming requests based on configured
+            # mode (force/retry/passthrough) to work around the "Streaming
+            # is required for operations that may take longer than 10
+            # minutes" error from the Anthropic API.
             if target_provider == "anthropic":
-                return await _passthrough_buffered_streaming(
-                    session, upstream_url, headers, body, source_provider
-                )
+                mode = config.anthropic_stream_mode
+                if mode == "force":
+                    return await _passthrough_buffered_streaming(
+                        session, upstream_url, headers, body, source_provider
+                    )
+                elif mode == "retry":
+                    return await _passthrough_with_retry(
+                        session, upstream_url, headers, body, source_provider
+                    )
+                # "passthrough": fall through to normal non-streaming
             return await _passthrough_non_streaming(
                 session, upstream_url, headers, body, source_provider
             )
@@ -1184,17 +1376,30 @@ async def proxy_request(
                 config,
             )
 
-        # Force streaming for Anthropic non-streaming requests (cross-format)
+        # Handle Anthropic non-streaming requests (cross-format)
         if target_provider == "anthropic":
-            return await _convert_buffered_streaming(
-                session,
-                upstream_url,
-                headers,
-                body,
-                source_provider,
-                target_provider,
-                config,
-            )
+            mode = config.anthropic_stream_mode
+            if mode == "force":
+                return await _convert_buffered_streaming(
+                    session,
+                    upstream_url,
+                    headers,
+                    body,
+                    source_provider,
+                    target_provider,
+                    config,
+                )
+            elif mode == "retry":
+                return await _convert_with_retry(
+                    session,
+                    upstream_url,
+                    headers,
+                    body,
+                    source_provider,
+                    target_provider,
+                    config,
+                )
+            # "passthrough": fall through to normal non-streaming
 
         return await _convert_non_streaming(
             session,


### PR DESCRIPTION
## Summary

- Add `--anthropic-stream-mode {force,retry,passthrough}` CLI option to control how non-streaming requests to Anthropic upstream are handled
  - `force` (default): always force streaming and aggregate back (current behavior, backward compatible)
  - `retry`: try non-streaming first, auto-retry with forced streaming on Anthropic's "streaming is required" bounce-back (HTTP 500), dumping the request for diagnostics
  - `passthrough`: never force streaming, pass through as-is
- Generalize `argo-proxy logs collect` with `--type {leaked-tool,stream-retry,all}` flag to support multiple diagnostic log categories

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes
- [x] Config field: default is `"force"`, `from_dict()` and `to_persistent_dict()` work correctly, invalid values fall back to `"force"`
- [x] CLI argument: `--anthropic-stream-mode` validates choices, maps to env var correctly
- [x] Error detection: `_is_anthropic_stream_required_error()` matches HTTP 500 + "streaming is required" (case-insensitive)
- [ ] Integration test: `--anthropic-stream-mode retry` with a real Anthropic request that triggers bounce-back
- [ ] Integration test: `--anthropic-stream-mode passthrough` passes non-streaming requests through unmodified