### PR TITLE
feat: dump request/response on upstream errors for diagnostics

### DIFF
--- a/src/argoproxy/cli/handlers.py
+++ b/src/argoproxy/cli/handlers.py
@@ -367,6 +367,7 @@ _DIAGNOSTIC_LOG_TYPES: dict[str, tuple[str, list[str]]] = {
         ["leaked_tool_*.json", "leaked_tool_*.json.gz"],
     ),
     "stream-retry": ("stream_retry_dumps", ["retry_*.json", "retry_*.json.gz"]),
+    "error-dump": ("error_dumps", ["error_*.json", "error_*.json.gz"]),
 }
 
 

--- a/src/argoproxy/cli/parser.py
+++ b/src/argoproxy/cli/parser.py
@@ -193,12 +193,13 @@ def _add_logs_subparsers(parser: argparse.ArgumentParser) -> None:
         "--type",
         "-t",
         type=str,
-        choices=["leaked-tool", "stream-retry", "all"],
+        choices=["leaked-tool", "stream-retry", "error-dump", "all"],
         default="all",
         help=(
             "Type of diagnostic logs to collect (default: all)\n"
             "  leaked-tool:  Leaked tool call logs\n"
             "  stream-retry: Anthropic stream retry request dumps\n"
+            "  error-dump:   Upstream error request/response dumps\n"
             "  all:          All diagnostic logs"
         ),
     )

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -146,15 +146,28 @@ def _is_anthropic_stream_required_error(status_code: int, error_text: str) -> bo
     return "streaming is required" in error_text.lower()
 
 
-def _dump_stream_retry_request(
+def _dump_error_request(
     request_body: dict[str, Any],
     error_status: int,
     error_text: str,
     upstream_url: str,
+    source_provider: ProviderType | None = None,
+    target_provider: ProviderType | None = None,
 ) -> None:
-    """Dump request details when retry mode triggers a forced-streaming retry.
+    """Dump request and error details to disk for diagnostics.
 
-    Saves a JSON file to ``<config_dir>/stream_retry_dumps/`` for diagnostics.
+    Saves a JSON file to ``<config_dir>/error_dumps/`` containing the
+    request body, upstream response status/text, URL, and provider context.
+    When the dump directory exceeds 50 MB, existing ``.json`` files are
+    automatically gzip-compressed.
+
+    Args:
+        request_body: The request payload sent (or intended) to upstream.
+        error_status: HTTP status code from the upstream response.
+        error_text: Body/text of the upstream error response.
+        upstream_url: The upstream URL the request was sent to.
+        source_provider: Client-side API format (e.g. ``"openai_chat"``).
+        target_provider: Upstream API format (e.g. ``"anthropic"``).
     """
     import gzip
     from datetime import datetime
@@ -163,9 +176,9 @@ def _dump_stream_retry_request(
     try:
         config_path = os.environ.get("CONFIG_PATH")
         if config_path:
-            log_dir = Path(config_path).parent / "stream_retry_dumps"
+            log_dir = Path(config_path).parent / "error_dumps"
         else:
-            log_dir = Path.cwd() / "stream_retry_dumps"
+            log_dir = Path.cwd() / "error_dumps"
 
         log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -173,11 +186,11 @@ def _dump_stream_retry_request(
         dir_size = sum(f.stat().st_size for f in log_dir.iterdir() if f.is_file())
         if dir_size > 50 * 1024 * 1024:
             log_warning(
-                f"Stream retry dump directory ({dir_size / 1024 / 1024:.2f}MB) "
+                f"Error dump directory ({dir_size / 1024 / 1024:.2f}MB) "
                 "exceeds 50MB, compressing logs...",
                 context="dispatch",
             )
-            for json_file in log_dir.glob("retry_*.json"):
+            for json_file in log_dir.glob("error_*.json"):
                 try:
                     gz_path = json_file.with_suffix(".json.gz")
                     with (
@@ -192,22 +205,43 @@ def _dump_stream_retry_request(
                     )
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        log_file = log_dir / f"retry_{timestamp}.json"
+        log_file = log_dir / f"error_{timestamp}.json"
 
-        entry = {
+        entry: dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
             "upstream_url": upstream_url,
             "error_status": error_status,
             "error_text": error_text,
+            "source_provider": source_provider,
+            "target_provider": target_provider,
             "request_body": request_body,
         }
 
         with open(log_file, "w", encoding="utf-8") as f:
             json.dump(entry, f, indent=2, ensure_ascii=False)
 
-        log_info(f"Dumped retry request to: {log_file}", context="dispatch")
+        log_info(f"Dumped error request to: {log_file}", context="dispatch")
     except Exception as exc:
-        log_error(f"Failed to dump retry request: {exc}", context="dispatch")
+        log_error(f"Failed to dump error request: {exc}", context="dispatch")
+
+
+def _dump_stream_retry_request(
+    request_body: dict[str, Any],
+    error_status: int,
+    error_text: str,
+    upstream_url: str,
+) -> None:
+    """Dump request details when retry mode triggers a forced-streaming retry.
+
+    Thin wrapper around :func:`_dump_error_request` kept for backward
+    compatibility with existing call sites.
+    """
+    _dump_error_request(
+        request_body,
+        error_status,
+        error_text,
+        upstream_url,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -557,6 +591,15 @@ async def _passthrough_non_streaming(
             if contains_argo_auth_warning(response_text):
                 log_error(ARGO_AUTH_ERROR_MESSAGE, context="dispatch")
                 return _error_response(source_provider, 403, ARGO_AUTH_ERROR_MESSAGE)
+            if upstream_resp.status >= 400:
+                _dump_error_request(
+                    data,
+                    upstream_resp.status,
+                    response_text,
+                    upstream_url,
+                    source_provider=source_provider,
+                    target_provider=source_provider,
+                )
             return web.Response(
                 text=response_text,
                 status=upstream_resp.status,
@@ -568,6 +611,16 @@ async def _passthrough_non_streaming(
         if check_response_for_argo_warning(response_data, upstream_provider):
             log_error(ARGO_AUTH_ERROR_MESSAGE, context="dispatch")
             return _error_response(source_provider, 403, ARGO_AUTH_ERROR_MESSAGE)
+
+        if upstream_resp.status >= 400:
+            _dump_error_request(
+                data,
+                upstream_resp.status,
+                json.dumps(response_data, ensure_ascii=False),
+                upstream_url,
+                source_provider=source_provider,
+                target_provider=source_provider,
+            )
 
         return web.json_response(
             response_data,
@@ -596,6 +649,14 @@ async def _passthrough_streaming(
                 error_text,
                 endpoint="dispatch_passthrough",
                 is_streaming=True,
+            )
+            _dump_error_request(
+                data,
+                upstream_resp.status,
+                error_text,
+                upstream_url,
+                source_provider=source_provider,
+                target_provider=target_provider,
             )
             return web.json_response(
                 {"error": f"Upstream API error: {upstream_resp.status} {error_text}"},
@@ -675,6 +736,14 @@ async def _passthrough_buffered_streaming(
                 error_text,
                 endpoint="dispatch_passthrough_buffered",
             )
+            _dump_error_request(
+                data,
+                upstream_resp.status,
+                error_text,
+                upstream_url,
+                source_provider=source_provider,
+                target_provider="anthropic",
+            )
             try:
                 error_json = json.loads(error_text)
                 return web.json_response(error_json, status=upstream_resp.status)
@@ -728,6 +797,16 @@ async def _passthrough_with_retry(
             if contains_argo_auth_warning(response_text):
                 log_error(ARGO_AUTH_ERROR_MESSAGE, context="dispatch")
                 return _error_response(source_provider, 403, ARGO_AUTH_ERROR_MESSAGE)
+
+            if status >= 400:
+                _dump_error_request(
+                    data,
+                    status,
+                    response_text,
+                    upstream_url,
+                    source_provider=source_provider,
+                    target_provider="anthropic",
+                )
 
             try:
                 response_data = json.loads(response_text)
@@ -818,6 +897,14 @@ async def _convert_non_streaming(
                     upstream_resp.status,
                     error_text,
                     endpoint=str(target_provider),
+                )
+                _dump_error_request(
+                    body,
+                    upstream_resp.status,
+                    error_text,
+                    upstream_url,
+                    source_provider=source_provider,
+                    target_provider=target_provider,
                 )
                 return web.Response(
                     text=error_text,
@@ -927,6 +1014,14 @@ async def _convert_buffered_streaming(
                     upstream_resp.status,
                     error_text,
                     endpoint=str(target_provider),
+                )
+                _dump_error_request(
+                    body,
+                    upstream_resp.status,
+                    error_text,
+                    upstream_url,
+                    source_provider=source_provider,
+                    target_provider=target_provider,
                 )
                 return web.Response(
                     text=error_text,
@@ -1069,6 +1164,14 @@ async def _convert_streaming(
                     endpoint=str(target_provider),
                     is_streaming=True,
                 )
+                _dump_error_request(
+                    body,
+                    upstream_resp.status,
+                    error_text,
+                    upstream_url,
+                    source_provider=source_provider,
+                    target_provider=target_provider,
+                )
                 return web.json_response(
                     {
                         "error": f"Upstream API error: {upstream_resp.status} {error_text}"
@@ -1150,6 +1253,14 @@ async def _convert_streaming(
                         log_warning(
                             f"Upstream error in stream chunk: {json.dumps(chunk_data)[:500]}",
                             context="dispatch",
+                        )
+                        _dump_error_request(
+                            body,
+                            upstream_resp.status,
+                            json.dumps(chunk_data, ensure_ascii=False),
+                            upstream_url,
+                            source_provider=source_provider,
+                            target_provider=target_provider,
                         )
 
                     # Upstream chunk → IR events


### PR DESCRIPTION
## Summary

- Generalize `_dump_stream_retry_request()` into `_dump_error_request()` that triggers on any upstream 4xx/5xx error across all dispatch paths
- Dumps include `source_provider`/`target_provider` context for easier debugging of cross-provider conversion issues
- Register `error-dump` as a diagnostic log type in the CLI `collect` command

## Motivation

Previously only stream-retry and stream-500 cases were dumped to disk. Errors like the `input_image` 400 from #99 were logged as one-line messages without the full request body, making reproduction and debugging very difficult.

## Test plan

- [ ] Trigger a 4xx error (e.g., invalid model name) and verify dump appears in `<config_dir>/error_dumps/`
- [ ] Verify dump includes `source_provider`, `target_provider`, request body, and error text
- [ ] Verify `argo-proxy collect --type error-dump` archives the dumps
- [ ] Verify existing stream-retry dump behavior is unchanged

Closes #100