### PR TITLE
fix: downgrade developer role to system for Argo gateway compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
     "aiohttp>=3.12.2",
-    "llm-rosetta>=0.4.1,<0.5.0",
+    "llm-rosetta>=0.5.0,<0.6.0",
     "PyYAML>=6.0.2",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -257,6 +257,26 @@ def _detect_stream(source_provider: ProviderType, body: dict[str, Any]) -> bool:
     return False
 
 
+def _downgrade_developer_role(body: dict[str, Any]) -> None:
+    """Replace ``developer`` role with ``system`` for upstream compatibility.
+
+    The ``developer`` role was introduced in the OpenAI 2024-12-17 API
+    version for reasoning models (o1/o3/o4).  Upstream gateways that use
+    an older API version (e.g. the ANL Argo gateway) reject it with a
+    misleading ``Unknown parameter: 'messages[0].tool_calls'`` error.
+    Mapping back to ``system`` is safe — all OpenAI models still accept it.
+
+    Args:
+        body: The request body (modified in-place).
+    """
+    messages = body.get("messages")
+    if not messages or not isinstance(messages, list):
+        return
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "developer":
+            msg["role"] = "system"
+
+
 def _sanitize_tool_schemas(body: dict[str, Any]) -> dict[str, Any]:
     """Sanitize tool parameter schemas for upstream compatibility.
 
@@ -878,6 +898,7 @@ async def _convert_non_streaming(
         log_info(f"Conversion warnings: {warnings}", context="dispatch")
 
     _ensure_user_field(target_body, config.user)
+    _downgrade_developer_role(target_body)
 
     # Log the converted body
     if config.verbose:
@@ -987,6 +1008,7 @@ async def _convert_buffered_streaming(
         log_info(f"Conversion warnings: {warnings}", context="dispatch")
 
     _ensure_user_field(target_body, config.user)
+    _downgrade_developer_role(target_body)
 
     # 3. Inject stream flags and update headers for streaming
     target_body = _inject_stream_flags(target_body, target_provider)
@@ -1149,6 +1171,7 @@ async def _convert_streaming(
         )
 
     _ensure_user_field(target_body, config.user)
+    _downgrade_developer_role(target_body)
 
     format_sse = _SSE_FORMATTERS[source_provider]
 
@@ -1420,6 +1443,10 @@ async def proxy_request(
             # Sanitize tool schemas even in passthrough mode — upstreams
             # like Vertex AI reject unsupported JSON Schema keywords.
             _sanitize_tool_schemas(body)
+
+            # Downgrade "developer" role to "system" — the Argo upstream
+            # gateway rejects "developer" with a misleading tool_calls error.
+            _downgrade_developer_role(body)
 
             # Fix orphaned tool_calls/results in passthrough mode — OpenAI
             # and Anthropic strictly require bidirectional pairing between


### PR DESCRIPTION
## Summary

- Map `developer` role → `system` in all outbound request paths before forwarding to upstream
- Fixes O3/o1/o4 requests failing through the ANL Argo gateway

## Root Cause

The ANL Argo gateway (`apps.inside.anl.gov/argoapi`) uses an older OpenAI SDK that does not recognize the `developer` role (introduced in OpenAI API 2024-12-17 for reasoning models). The gateway's SDK mishandles the unrecognized role, injecting a spurious `tool_calls` field into the message, causing OpenAI to reject the request with a misleading error:

```
Unknown parameter: 'messages[0].tool_calls'
```

### Causal chain

1. Client sends `role: "developer"` in `messages[0]` (correct per OpenAI spec for o3)
2. argo-proxy (passthrough mode) forwards the request body as-is to `apps.inside.anl.gov/argoapi`
3. Argo gateway's older SDK doesn't recognize `developer` role → injects spurious `tool_calls` field
4. OpenAI API receives the malformed request → rejects with misleading error

### Evidence

| Test | Result |
|------|--------|
| `developer` role + tools → Argo gateway | ❌ `messages[0].tool_calls` error |
| `developer` role, **no tools** → Argo gateway | ❌ Same error (not tool-related) |
| `system` role + tools → Argo gateway | ✅ |
| `developer` role → direct Argo API (bypass proxy) | ❌ Same error (not our fault) |
| `developer` role → **patched proxy** (developer→system) | ✅ |
| Rick's full 24-tool GeoBenchX request → patched proxy | ✅ |

## Test plan

- [x] Verified `developer` role request fails on unpatched path (baseline)
- [x] Verified patched proxy correctly downgrades and succeeds
- [x] Verified with Rick's full production request (24 tools, GeoBenchX)
- [x] `ruff check` and `ruff format` pass

Closes #107