### PR TITLE
feat: add --dump-requests CLI option for debug request/response dumping

### DIFF
--- a/src/argoproxy/cli/handlers.py
+++ b/src/argoproxy/cli/handlers.py
@@ -51,6 +51,10 @@ def set_config_envs(args: argparse.Namespace):
         os.environ["ANTHROPIC_STREAM_MODE"] = args.anthropic_stream_mode
     if args.force_conversion:
         os.environ["FORCE_CONVERSION"] = str(True)
+    if args.dump_requests:
+        os.environ["DUMP_REQUESTS"] = str(True)
+    if args.dump_dir:
+        os.environ["DUMP_DIR"] = args.dump_dir
 
 
 def handle_serve(args: argparse.Namespace):

--- a/src/argoproxy/cli/parser.py
+++ b/src/argoproxy/cli/parser.py
@@ -105,6 +105,21 @@ def _add_serve_arguments(parser: argparse.ArgumentParser) -> None:
         help="Always run full format conversion, even for same-provider requests",
     )
     parser.add_argument(
+        "--dump-requests",
+        action="store_true",
+        default=False,
+        help="Dump request/response JSON at each processing stage for debugging",
+    )
+    parser.add_argument(
+        "--dump-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory for debug request/response dumps "
+            "(default: dumps/ next to config file)"
+        ),
+    )
+    parser.add_argument(
         "--dev",
         action="store_true",
         default=False,

--- a/src/argoproxy/config/io.py
+++ b/src/argoproxy/config/io.py
@@ -183,6 +183,12 @@ def _apply_env_overrides(config_data: ArgoConfig) -> ArgoConfig:
     if env_force_conversion := os.getenv("FORCE_CONVERSION"):
         config_data._force_conversion = str_to_bool(env_force_conversion)
 
+    if env_dump_requests := os.getenv("DUMP_REQUESTS"):
+        config_data._dump_requests = str_to_bool(env_dump_requests)
+
+    if env_dump_dir := os.getenv("DUMP_DIR"):
+        config_data._dump_dir = env_dump_dir
+
     return config_data
 
 

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -67,6 +67,10 @@ class ArgoConfig:
     # Force full conversion even for same-provider requests
     _force_conversion: bool = False
 
+    # Debug request/response dumping
+    _dump_requests: bool = False
+    _dump_dir: str = ""
+
     # Validation and resolver settings
     _skip_url_validation: bool = False
     _user_validated: bool = False  # Set after upstream user validation passes
@@ -214,6 +218,37 @@ class ArgoConfig:
         """
         return self._force_conversion
 
+    @property
+    def dump_requests(self) -> bool:
+        """Whether to dump request/response JSON at each processing stage.
+
+        When enabled, the dispatch module writes JSON files to
+        ``dump_dir`` at various stages (request received, converted,
+        response received, response converted) for debugging.
+        """
+        return self._dump_requests
+
+    @property
+    def dump_dir(self) -> str:
+        """Directory for debug request/response dumps.
+
+        Resolution order:
+        1. Explicitly configured ``_dump_dir`` value.
+        2. ``dumps/`` subdirectory next to the config file (if CONFIG_PATH
+           is set).
+        3. ``/tmp/argo_debug_dumps`` as a last-resort fallback.
+        """
+        import os
+
+        if self._dump_dir:
+            return self._dump_dir
+        config_path = os.environ.get("CONFIG_PATH")
+        if config_path:
+            from pathlib import Path
+
+            return str(Path(config_path).parent / "dumps")
+        return "/tmp/argo_debug_dumps"
+
     @classmethod
     def from_dict(cls, config_dict: dict):
         """Create ArgoConfig instance from a dictionary."""
@@ -230,6 +265,8 @@ class ArgoConfig:
             "skip_url_validation": "_skip_url_validation",
             "anthropic_stream_mode": "_anthropic_stream_mode",
             "force_conversion": "_force_conversion",
+            "dump_requests": "_dump_requests",
+            "dump_dir": "_dump_dir",
         }
         valid_fields = {
             k: v for k, v in config_dict.items() if k in cls.__annotations__
@@ -265,6 +302,10 @@ class ArgoConfig:
             serialized["anthropic_stream_mode"] = self._anthropic_stream_mode
         if self._force_conversion:
             serialized["force_conversion"] = True
+        if self._dump_requests:
+            serialized["dump_requests"] = True
+        if self._dump_dir:
+            serialized["dump_dir"] = self._dump_dir
 
         # Persist native URLs only when explicitly overridden (differ from
         # the values that would be derived from argo_base_url)

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -660,8 +660,12 @@ async def _passthrough_non_streaming(
     headers: dict[str, str],
     data: dict[str, Any],
     source_provider: ProviderType = "openai_chat",
+    *,
+    config: ArgoConfig | None = None,
 ) -> web.Response:
     """Forward request to upstream and return response without conversion."""
+    if config:
+        _debug_dump("pt_request", data, config)
     async with session.post(upstream_url, headers=headers, json=data) as upstream_resp:
         try:
             response_data = await upstream_resp.json()
@@ -701,6 +705,8 @@ async def _passthrough_non_streaming(
                 target_provider=source_provider,
             )
 
+        if config:
+            _debug_dump("pt_response", response_data, config)
         return web.json_response(
             response_data,
             status=upstream_resp.status,
@@ -716,8 +722,12 @@ async def _passthrough_streaming(
     request: web.Request,
     target_provider: ProviderType,
     source_provider: ProviderType = "openai_chat",
+    *,
+    config: ArgoConfig | None = None,
 ) -> web.StreamResponse:
     """Forward streaming request to upstream and pipe bytes directly."""
+    if config:
+        _debug_dump("pts_request", data, config)
     data = _inject_stream_flags(data, target_provider)
 
     async with session.post(upstream_url, headers=headers, json=data) as upstream_resp:
@@ -916,6 +926,34 @@ async def _passthrough_with_retry(
 
 
 # ---------------------------------------------------------------------------
+# Debug dump helper
+# ---------------------------------------------------------------------------
+
+
+def _debug_dump(stage: str, data: Any, config: ArgoConfig) -> None:
+    """Write a JSON dump to ``config.dump_dir``/<timestamp>_<stage>.json.
+
+    The dump is a no-op when ``config.dump_requests`` is False.
+
+    Args:
+        stage: Short label describing the processing stage (e.g.
+            ``"1_request_received"``).
+        data: Payload to serialize as JSON.
+        config: The current ArgoConfig instance (controls whether
+            dumping is enabled and where files are written).
+    """
+    if not config.dump_requests:
+        return
+    dump_dir = config.dump_dir
+    os.makedirs(dump_dir, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    path = os.path.join(dump_dir, f"{ts}_{stage}.json")
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+    log_debug(f"Debug dump: {path}", context="dispatch")
+
+
+# ---------------------------------------------------------------------------
 # Cross-format conversion handlers
 # ---------------------------------------------------------------------------
 
@@ -935,6 +973,7 @@ async def _convert_non_streaming(
     ctx = ConversionContext(options={"metadata_mode": "preserve"})
 
     # 1. Source → IR
+    _debug_dump("1_request_received", body, config)
     try:
         ir_request = source_converter.request_from_provider(body, context=ctx)
     except Exception as exc:
@@ -960,6 +999,7 @@ async def _convert_non_streaming(
     _ensure_user_field(target_body, config.user)
     _downgrade_developer_role(target_body)
     _normalize_null_content(target_body)
+    _debug_dump("2_request_converted", target_body, config)
 
     # Log the converted body
     if config.verbose:
@@ -1001,6 +1041,7 @@ async def _convert_non_streaming(
                 return _error_response(
                     source_provider, 502, "Upstream returned non-JSON response"
                 )
+            _debug_dump("3_response_received", upstream_json, config)
 
             # Check for ARGO auth warning before conversion
             upstream_fmt = "anthropic" if target_provider == "anthropic" else "openai"
@@ -1031,6 +1072,7 @@ async def _convert_non_streaming(
                     f"Failed to convert response: {exc}",
                 )
 
+            _debug_dump("4_response_converted", source_response, config)
             return web.json_response(source_response)
 
     except aiohttp.ClientError as exc:
@@ -1218,6 +1260,7 @@ async def _convert_streaming(
     ctx = ConversionContext(options={"metadata_mode": "preserve"})
 
     # 1. Source → IR
+    _debug_dump("s1_request_received", body, config)
     try:
         ir_request = source_converter.request_from_provider(body, context=ctx)
     except Exception as exc:
@@ -1239,6 +1282,7 @@ async def _convert_streaming(
 
     # 3. Inject stream flags
     target_body = _inject_stream_flags(target_body, target_provider)
+    _debug_dump("s2_request_converted", target_body, config)
     if config.verbose:
         log_converted_request(
             target_body, verbose=True, max_history_items=config.max_log_history
@@ -1292,6 +1336,8 @@ async def _convert_streaming(
             chunk_count = 0
             t0 = time.monotonic()
             _auth_checked = False
+            _raw_chunks: list[Any] = []
+            _converted_chunks: list[Any] = []
 
             # Buffer for partial SSE lines from byte chunks
             line_buffer = ""
@@ -1345,6 +1391,8 @@ async def _convert_streaming(
 
                     chunk_count += 1
 
+                    _raw_chunks.append(chunk_data)
+
                     # Log first chunk and error chunks for diagnostics
                     if chunk_count == 1 and config.verbose:
                         log_debug(
@@ -1375,6 +1423,7 @@ async def _convert_streaming(
                         source_chunks = source_converter.stream_response_to_provider(
                             ir_event, context=to_ctx
                         )
+                        _converted_chunks.extend(source_chunks)
                         await _write_sse_chunks(response, source_chunks, format_sse)
 
             # Ensure response is prepared even if no chunks were received
@@ -1407,6 +1456,9 @@ async def _convert_streaming(
             # Emit end-of-stream marker for OpenAI Chat
             if source_provider == "openai_chat":
                 await response.write(b"data: [DONE]\n\n")
+
+            _debug_dump("s3_all_chunks_received", _raw_chunks, config)
+            _debug_dump("s4_all_chunks_converted", _converted_chunks, config)
 
             if config.verbose:
                 elapsed = time.monotonic() - t0
@@ -1578,6 +1630,7 @@ async def proxy_request(
                     request,
                     target_provider,
                     source_provider,
+                    config=config,
                 )
             # Handle Anthropic non-streaming requests based on configured
             # mode (force/retry/passthrough) to work around the "Streaming
@@ -1595,7 +1648,7 @@ async def proxy_request(
                     )
                 # "passthrough": fall through to normal non-streaming
             return await _passthrough_non_streaming(
-                session, upstream_url, headers, body, source_provider
+                session, upstream_url, headers, body, source_provider, config=config
             )
 
         # Cross-format conversion (or forced same-format conversion)


### PR DESCRIPTION
## Summary

- Converts temporary hardcoded debug dump code in `dispatch.py` into a proper CLI-configurable feature
- Adds `--dump-requests` and `--dump-dir` flags to the `serve` subcommand, with corresponding `ArgoConfig` fields (`dump_requests`, `dump_dir`) and environment variable overrides (`DUMP_REQUESTS`, `DUMP_DIR`)
- The `_debug_dump` helper is now a no-op unless `config.dump_requests` is True, and writes to `config.dump_dir` instead of a hardcoded `/tmp/argo_debug_dumps` path
- `dump_dir` defaults to `dumps/` next to the config file (when `CONFIG_PATH` is set), falling back to `/tmp/argo_debug_dumps`

## Changed files

- `src/argoproxy/cli/parser.py` -- add `--dump-requests` and `--dump-dir` arguments
- `src/argoproxy/cli/handlers.py` -- wire CLI flags to `DUMP_REQUESTS` / `DUMP_DIR` env vars
- `src/argoproxy/config/model.py` -- add `_dump_requests`, `_dump_dir` fields, properties, field mapping, and persistence
- `src/argoproxy/config/io.py` -- add env var overrides for `DUMP_REQUESTS` and `DUMP_DIR`
- `src/argoproxy/endpoints/dispatch.py` -- refactor `_debug_dump` to accept `config`, update all call sites, remove hardcoded `_DUMP_DIR` and unused `tempfile` import

## Test plan

- [x] Run `argo-proxy serve config.yaml` without `--dump-requests` and verify no dump files are created
- [x] Run `argo-proxy serve config.yaml --dump-requests` and send a request; verify JSON dumps appear in `dumps/` next to the config file
- [x] Run with `--dump-requests --dump-dir /tmp/custom_dumps` and verify dumps go to the custom directory
- [x] Verify passthrough (same-format), cross-format non-streaming, and cross-format streaming paths all produce dumps when enabled
- [x] Run `ruff check` and `ruff format` -- all clean