### PR TITLE
fix: normalize thinking in force-conversion paths

### DIFF
--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -1319,6 +1319,7 @@ async def _convert_streaming(
     _ensure_user_field(target_body, config.user)
     _downgrade_developer_role(target_body)
     _normalize_null_content(target_body)
+    _normalize_thinking_for_upstream(target_body)
 
     format_sse = _SSE_FORMATTERS[source_provider]
 

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -1025,6 +1025,7 @@ async def _convert_non_streaming(
     _ensure_user_field(target_body, config.user)
     _downgrade_developer_role(target_body)
     _normalize_null_content(target_body)
+    _normalize_thinking_for_upstream(target_body)
     _debug_dump("2_request_converted", target_body, config)
 
     # Log the converted body
@@ -1146,6 +1147,7 @@ async def _convert_buffered_streaming(
     _ensure_user_field(target_body, config.user)
     _downgrade_developer_role(target_body)
     _normalize_null_content(target_body)
+    _normalize_thinking_for_upstream(target_body)
 
     # 3. Inject stream flags and update headers for streaming
     target_body = _inject_stream_flags(target_body, target_provider)


### PR DESCRIPTION
## Summary

- `_normalize_thinking_for_upstream` was only called in the passthrough path, missing from both `_convert_non_streaming` and `_convert_buffered_streaming`
- When `--force-conversion` is active, `thinking.type=enabled` was sent to Argo as-is → Argo rejects it for opus-4.7 (requires `adaptive`) → 502 on all non-streaming requests
- Added the normalize call to both conversion paths, matching the passthrough path

## Test plan

- [x] Verified on lambda5: non-streaming `claude-opus-4.7` with `thinking.type=enabled` now returns 200
- [x] Verified with tool_use + thinking: returns 200
- [x] End-to-end through SSH tunnel from cloud.usa2: returns 200

Closes #123