### PR TITLE
Add periodic auto-refresh for model list

### DIFF
--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -72,6 +72,9 @@ class ArgoConfig:
     log_to_file: bool = False  # Enable file logging alongside stdout
     max_log_history: int = 3  # Keep last N messages in verbose request logs
 
+    # Model list auto-refresh
+    model_refresh_interval_hours: float = 24  # 0 to disable
+
     # Image processing settings
     enable_payload_control: bool = False  # Enable automatic payload size control
     max_payload_size: int = 20  # MB default (total for all images)
@@ -258,6 +261,10 @@ class ArgoConfig:
             serialized["dump_requests"] = True
         if self._dump_dir:
             serialized["dump_dir"] = self._dump_dir
+
+        # Persist model refresh interval only when non-default
+        if self.model_refresh_interval_hours == 24:
+            serialized.pop("model_refresh_interval_hours", None)
 
         # Persist native URLs only when explicitly overridden (differ from
         # the values that would be derived from argo_base_url)

--- a/src/argoproxy/models.py
+++ b/src/argoproxy/models.py
@@ -556,10 +556,16 @@ class ModelRegistry:
                 f"Initial availability check failed: {str(e)}", context="ModelRegistry"
             )
 
-        # # Start periodic refresh (default 24h)
-        # self._refresh_task = asyncio.create_task(
-        #     self._periodic_refresh(interval_hours=24)
-        # )
+        # Start periodic refresh if configured
+        interval = self._config.model_refresh_interval_hours
+        if interval > 0:
+            self._refresh_task = asyncio.create_task(
+                self._periodic_refresh(interval_hours=interval)
+            )
+            log_info(
+                f"Periodic model refresh enabled: every {interval}h",
+                context="ModelRegistry",
+            )
 
     async def refresh_availability(self, real_test: bool = False):
         """Refresh model availability status"""
@@ -638,14 +644,27 @@ class ModelRegistry:
                     "Falling back to default model list", context="ModelRegistry"
                 )
 
-    # async def _periodic_refresh(self, interval_hours: float):
-    #     """Background task for periodic refresh"""
-    #     while True:
-    #         await asyncio.sleep(interval_hours * 3600)
-    #         try:
-    #             await self.refresh_availability()
-    #         except Exception as e:
-    #             logger.error(f"Periodic refresh failed: {str(e)}")
+    async def _periodic_refresh(self, interval_hours: float):
+        """Background task that refreshes the model list on a fixed interval."""
+        try:
+            while True:
+                await asyncio.sleep(interval_hours * 3600)
+                log_info(
+                    f"Periodic model refresh triggered (every {interval_hours}h)",
+                    context="ModelRegistry",
+                )
+                try:
+                    await self.refresh_availability()
+                except Exception as e:
+                    log_error(
+                        f"Periodic refresh failed: {e!s}",
+                        context="ModelRegistry",
+                    )
+        except asyncio.CancelledError:
+            log_debug(
+                "Periodic model refresh task cancelled",
+                context="ModelRegistry",
+            )
 
     async def manual_refresh(self):
         """Trigger manual refresh of model data"""


### PR DESCRIPTION
## Summary

- Enable periodic background refresh of the model list from upstream ARGO API (default: every 24 hours)
- New config field `model_refresh_interval_hours` (set to `0` to disable)
- Skeleton code was already present (commented out) — this uncomments, fixes, and wires it up properly
- Clean shutdown via `asyncio.CancelledError` handling; existing `cleanup_app` already cancels all tasks

## Test plan

- [x] Config round-trip: default (24) not persisted, custom values (12, 0) persisted correctly
- [x] `ruff check` + `ruff format` clean
- [ ] Start argo-proxy, verify "Periodic model refresh enabled: every 24.0h" in startup log
- [ ] Set `model_refresh_interval_hours: 0`, verify no periodic task created
- [ ] `POST /refresh` still works manually (unchanged)