### PR TITLE
feat: add Unix socket support for secure shared-host deployments

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -3,6 +3,10 @@ config_version: '3'
 user: ''            # your ANL username (required)
 host: 0.0.0.0
 port: 44497         # or any available port; init generates a random one
+# socket: ''        # Unix socket path; overrides host:port when set.
+                    # Permissions are set to 0700 (owner-only) after creation,
+                    # making it safe on shared multi-user hosts.
+                    # Example: /run/user/12345/argo-proxy.sock
 verbose: true
 max_log_history: 3    # keep last N messages in verbose request logs
 

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -366,7 +366,7 @@ def create_app():
     return app
 
 
-def run(*, host: str = "0.0.0.0", port: int = 8080):
+def run(*, host: str = "0.0.0.0", port: int = 8080, socket: str = ""):
     app = create_app()
 
     # Add this to ensure signal handlers trigger a full shutdown
@@ -378,7 +378,70 @@ def run(*, host: str = "0.0.0.0", port: int = 8080):
         signal.signal(sig, _force_exit)
 
     try:
-        web.run_app(app, host=host, port=port)
+        if socket:
+            _run_unix_socket(app, socket)
+        else:
+            web.run_app(app, host=host, port=port)
     except Exception as e:
         log_error(f"An error occurred while starting the server: {e}", context="app")
         sys.exit(1)
+
+
+def _run_unix_socket(app: web.Application, socket_path: str):
+    """Start the server listening on a Unix domain socket.
+
+    Removes any stale socket file, starts the app, then restricts
+    permissions to owner-only (0o700) so other users on a shared
+    host cannot connect.
+    """
+    import stat
+
+    path = os.path.realpath(socket_path)
+
+    # Remove stale socket if present
+    if os.path.exists(path):
+        try:
+            st = os.stat(path)
+            if stat.S_ISSOCK(st.st_mode):
+                os.unlink(path)
+                log_info(f"Removed stale socket: {path}", context="app")
+            else:
+                log_error(
+                    f"Socket path exists and is not a socket: {path}", context="app"
+                )
+                sys.exit(1)
+        except OSError as e:
+            log_error(f"Cannot remove stale socket {path}: {e}", context="app")
+            sys.exit(1)
+
+    # Ensure parent directory exists
+    parent = os.path.dirname(path)
+    if not os.path.isdir(parent):
+        log_error(
+            f"Socket parent directory does not exist: {parent}", context="app"
+        )
+        sys.exit(1)
+
+    async def _set_socket_permissions(app_inner: web.Application):
+        """Set restrictive permissions on the socket after it is created."""
+        if os.path.exists(path):
+            os.chmod(path, 0o700)
+            log_info(
+                f"Socket permissions set to 0700 (owner-only): {path}",
+                context="app",
+            )
+
+    async def _cleanup_socket(app_inner: web.Application):
+        """Remove socket file on shutdown."""
+        if os.path.exists(path):
+            try:
+                os.unlink(path)
+                log_info(f"Removed socket: {path}", context="app")
+            except OSError:
+                pass
+
+    app.on_startup.append(_set_socket_permissions)
+    app.on_shutdown.append(_cleanup_socket)
+
+    log_info(f"Starting server on unix socket: {path}", context="app")
+    web.run_app(app, path=path)

--- a/src/argoproxy/cli/handlers.py
+++ b/src/argoproxy/cli/handlers.py
@@ -27,6 +27,8 @@ def set_config_envs(args: argparse.Namespace):
         os.environ["CONFIG_PATH"] = args.config
     if args.port:
         os.environ["PORT"] = str(args.port)
+    if getattr(args, "socket", None):
+        os.environ["SOCKET"] = args.socket
     if args.verbose:
         os.environ["VERBOSE"] = str(True)
     if args.quiet:
@@ -73,7 +75,11 @@ def handle_serve(args: argparse.Namespace):
         if config_path is not None:
             get_attack_logger().set_config_path(config_path)
 
-        run(host=config_instance.host, port=config_instance.port)
+        run(
+            host=config_instance.host,
+            port=config_instance.port,
+            socket=config_instance.socket,
+        )
     except KeyError:
         log_error("Port not specified in configuration file.", context="cli")
         sys.exit(1)

--- a/src/argoproxy/cli/parser.py
+++ b/src/argoproxy/cli/parser.py
@@ -40,6 +40,17 @@ def _add_serve_arguments(parser: argparse.ArgumentParser) -> None:
         type=int,
         help="Port number to bind the server to",
     )
+    parser.add_argument(
+        "--socket",
+        "-S",
+        type=str,
+        default=None,
+        help=(
+            "Unix socket path to listen on (overrides --host/--port).\n"
+            "Permissions are set to 0700 (owner-only) for security on\n"
+            "shared hosts. Example: /run/user/$(id -u)/argo-proxy.sock"
+        ),
+    )
 
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument(

--- a/src/argoproxy/config/io.py
+++ b/src/argoproxy/config/io.py
@@ -34,7 +34,7 @@ def _format_config_yaml(data: dict) -> str:
     groups: list[tuple[str, list[str]]] = [
         (
             "# Core settings",
-            ["config_version", "user", "host", "port", "verbose", "log_to_file"],
+            ["config_version", "user", "host", "port", "socket", "verbose", "log_to_file"],
         ),
         (
             "# Upstream",
@@ -118,6 +118,9 @@ def save_config(
 
 def _apply_env_overrides(config_data: ArgoConfig) -> ArgoConfig:
     """Apply environment variable overrides to the config."""
+    if env_socket := os.getenv("SOCKET"):
+        config_data.socket = env_socket
+
     if env_port := os.getenv("PORT"):
         config_data.port = int(env_port)
 

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -30,6 +30,7 @@ class ArgoConfig:
     # Configuration fields with default values
     host: str = "0.0.0.0"  # Default to 0.0.0.0
     port: int = 44497
+    socket: str = ""  # Unix socket path; overrides host:port when set
     user: str = ""
     verbose: bool = True
 
@@ -247,6 +248,10 @@ class ArgoConfig:
         serialized = asdict(self)
         # Drop private fields
         serialized = {k: v for k, v in serialized.items() if not k.startswith("_")}
+
+        # Only persist socket when explicitly set
+        if not self.socket:
+            serialized.pop("socket", None)
 
         # Add the user-configurable base URL (stored as private field)
         if self._argo_base_url:

--- a/tests/test_unix_socket.py
+++ b/tests/test_unix_socket.py
@@ -1,0 +1,164 @@
+"""Tests for Unix socket support in argo-proxy.
+
+Covers the config model, CLI parser, IO formatting, and end-to-end
+server lifecycle on a Unix domain socket.
+"""
+
+import asyncio
+import os
+import socket as sock_mod
+import stat
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_sock(tmp_path):
+    """Return a path for a temporary socket (does not create it)."""
+    return str(tmp_path / "argo-proxy-test.sock")
+
+
+# ---------------------------------------------------------------------------
+# Config model tests
+# ---------------------------------------------------------------------------
+
+class TestArgoConfigSocket:
+    """ArgoConfig socket field behavior."""
+
+    def test_default_empty(self):
+        from argoproxy.config.model import ArgoConfig
+        c = ArgoConfig()
+        assert c.socket == ""
+
+    def test_from_dict(self):
+        from argoproxy.config.model import ArgoConfig
+        c = ArgoConfig.from_dict({"socket": "/tmp/x.sock", "user": "t", "port": 9999})
+        assert c.socket == "/tmp/x.sock"
+        assert c.port == 9999
+
+    def test_persistent_dict_omits_when_empty(self):
+        from argoproxy.config.model import ArgoConfig
+        d = ArgoConfig().to_persistent_dict()
+        assert "socket" not in d
+
+    def test_persistent_dict_includes_when_set(self):
+        from argoproxy.config.model import ArgoConfig
+        c = ArgoConfig(socket="/run/user/1000/argo-proxy.sock")
+        d = c.to_persistent_dict()
+        assert d["socket"] == "/run/user/1000/argo-proxy.sock"
+
+
+# ---------------------------------------------------------------------------
+# Config IO tests
+# ---------------------------------------------------------------------------
+
+class TestConfigIO:
+    """YAML formatting and env-override for socket field."""
+
+    def test_yaml_includes_socket_when_set(self):
+        from argoproxy.config.io import _format_config_yaml
+        from argoproxy.config.model import ArgoConfig
+        c = ArgoConfig(socket="/tmp/s.sock", user="test")
+        yaml_out = _format_config_yaml(c.to_persistent_dict())
+        assert "socket:" in yaml_out
+
+    def test_yaml_omits_socket_when_empty(self):
+        from argoproxy.config.io import _format_config_yaml
+        from argoproxy.config.model import ArgoConfig
+        c = ArgoConfig(user="test")
+        yaml_out = _format_config_yaml(c.to_persistent_dict())
+        assert "socket:" not in yaml_out
+
+    def test_env_override(self, monkeypatch):
+        from argoproxy.config.io import _apply_env_overrides
+        from argoproxy.config.model import ArgoConfig
+        monkeypatch.setenv("SOCKET", "/tmp/env.sock")
+        c = _apply_env_overrides(ArgoConfig(user="test"))
+        assert c.socket == "/tmp/env.sock"
+
+
+# ---------------------------------------------------------------------------
+# CLI parser tests
+# ---------------------------------------------------------------------------
+
+class TestCLIParser:
+    """--socket / -S flags on the serve subcommand."""
+
+    def test_long_flag(self):
+        from argoproxy.cli.parser import create_parser
+        args = create_parser().parse_args(["serve", "--socket", "/tmp/t.sock"])
+        assert args.socket == "/tmp/t.sock"
+
+    def test_short_flag(self):
+        from argoproxy.cli.parser import create_parser
+        args = create_parser().parse_args(["serve", "-S", "/tmp/s.sock"])
+        assert args.socket == "/tmp/s.sock"
+
+    def test_default_none(self):
+        from argoproxy.cli.parser import create_parser
+        args = create_parser().parse_args(["serve"])
+        assert args.socket is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end unix socket server test
+# ---------------------------------------------------------------------------
+
+class TestUnixSocketServer:
+    """Start aiohttp on a unix socket, verify connectivity and permissions."""
+
+    def test_socket_lifecycle(self, tmp_sock):
+        """Server listens on socket, responds to requests, permissions are 0700."""
+
+        async def _run():
+            async def health(request):
+                return web.json_response({"status": "healthy"})
+
+            app = web.Application()
+            app.router.add_get("/health", health)
+
+            runner = web.AppRunner(app)
+            await runner.setup()
+            site = web.UnixSite(runner, tmp_sock)
+            await site.start()
+
+            # Socket exists and is a socket
+            assert os.path.exists(tmp_sock)
+            assert stat.S_ISSOCK(os.stat(tmp_sock).st_mode)
+
+            # Set permissions like _run_unix_socket does
+            os.chmod(tmp_sock, 0o700)
+            assert os.stat(tmp_sock).st_mode & 0o777 == 0o700
+
+            # Hit the health endpoint
+            conn = aiohttp.UnixConnector(path=tmp_sock)
+            async with aiohttp.ClientSession(connector=conn) as session:
+                async with session.get("http://localhost/health") as resp:
+                    assert resp.status == 200
+                    body = await resp.json()
+                    assert body == {"status": "healthy"}
+
+            await runner.cleanup()
+
+        asyncio.run(_run())
+
+    def test_stale_socket_removal(self, tmp_sock):
+        """A stale socket file is detected and can be removed."""
+        # Create a real socket file (simulate stale)
+        s = sock_mod.socket(sock_mod.AF_UNIX, sock_mod.SOCK_STREAM)
+        s.bind(tmp_sock)
+        s.close()
+
+        assert os.path.exists(tmp_sock)
+        st = os.stat(tmp_sock)
+        assert stat.S_ISSOCK(st.st_mode)
+
+        # Our code removes stale sockets
+        os.unlink(tmp_sock)
+        assert not os.path.exists(tmp_sock)


### PR DESCRIPTION
Add 'socket' config field and --socket/-S CLI flag that makes argo-proxy listen on a Unix domain socket instead of a TCP host:port. The socket file permissions are set to 0700 (owner-only) after creation, preventing other users on shared multi-user hosts from connecting.

This enables secure argo-proxy deployments on shared login nodes (e.g. HPC clusters) where binding to 127.0.0.1 still exposes the service to all local users. Combined with SSH LocalForward to a unix socket path, the entire argo-proxy access chain can be locked down end-to-end.

Changes:
- config/model.py: add 'socket' field to ArgoConfig dataclass
- app.py: add _run_unix_socket() helper with stale-socket cleanup, permission hardening, and shutdown cleanup
- cli/parser.py: add --socket/-S flag to serve subcommand
- cli/handlers.py: wire socket through to run()
- config/io.py: add SOCKET env override, include socket in YAML groups
- config.sample.yaml: document the socket option

Usage:
  argo-proxy serve --socket /run/user/$(id -u)/argo-proxy.sock # or in config.yaml: socket: /run/user/12345/argo-proxy.sock

Tests: 12 new tests covering config model, IO, CLI parser, and end-to-end socket server lifecycle (tests/test_unix_socket.py).