### PR TITLE
fix: pass through client User-Agent instead of leaking argo-proxy version

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -92,7 +92,6 @@ async def prepare_app(app):
     # Create optimized HTTP session
     resolve_overrides = getattr(app["config"], "resolve_overrides", None)
     http_session_manager = OptimizedHTTPSession(
-        user_agent=f"argo-proxy/{__version__}",
         resolve_overrides=resolve_overrides if resolve_overrides else None,
         **perf_config,
     )

--- a/src/argoproxy/endpoints/dispatch.py
+++ b/src/argoproxy/endpoints/dispatch.py
@@ -288,6 +288,11 @@ def _build_upstream_headers(
     """Build HTTP headers for the upstream API request."""
     headers: dict[str, str] = {"Content-Type": "application/json"}
 
+    # Pass through client's User-Agent to upstream (transparent proxy)
+    client_ua = request.headers.get("User-Agent")
+    if client_ua:
+        headers["User-Agent"] = client_ua
+
     if should_use_username_passthrough():
         api_key = _extract_client_credential(request, target_provider) or fallback_user
     else:

--- a/src/argoproxy/models.py
+++ b/src/argoproxy/models.py
@@ -308,7 +308,6 @@ async def get_upstream_model_list_async(
         async with aiohttp.ClientSession(
             connector=connector,
             timeout=client_timeout,
-            headers={"User-Agent": "argo-proxy/1.0"},
         ) as session:
             log_debug(f"Sending request to: {url}", context="models")
 

--- a/src/argoproxy/performance.py
+++ b/src/argoproxy/performance.py
@@ -93,7 +93,6 @@ class OptimizedHTTPSession:
         read_timeout: Socket read timeout in seconds.
         total_timeout: Total request timeout in seconds.
         dns_cache_ttl: DNS cache TTL in seconds.
-        user_agent: User agent string.
         resolve_overrides: Optional dict mapping "host:port" to IP address
             for custom DNS resolution (similar to curl --resolve).
     """
@@ -108,7 +107,6 @@ class OptimizedHTTPSession:
         read_timeout: int = 30,
         total_timeout: int = 60,
         dns_cache_ttl: int = 300,
-        user_agent: str = "argo-proxy",
         resolve_overrides: dict[str, str] | None = None,
     ):
         connector_kwargs: dict = {
@@ -137,7 +135,6 @@ class OptimizedHTTPSession:
         )
 
         self.session: aiohttp.ClientSession | None = None
-        self.user_agent = user_agent
 
     async def create_session(self) -> aiohttp.ClientSession:
         """Create and return the HTTP session."""
@@ -145,7 +142,6 @@ class OptimizedHTTPSession:
             self.session = aiohttp.ClientSession(
                 connector=self.connector,
                 timeout=self.timeout,
-                headers={"User-Agent": self.user_agent},
             )
             log_debug(
                 f"HTTP session created: {self.connector.limit} total, "


### PR DESCRIPTION
## Summary

argo-proxy is a transparent proxy and should not inject its own identity into upstream requests.

### Problem

The `aiohttp` session set a default `User-Agent: argo-proxy/{version}` header on every outbound request, exposing the proxy's existence and version to the upstream Argo gateway. This is how the gateway maintainer was able to correlate caching behavior with specific argo-proxy versions.

### Fix

- **Dispatch mode**: pass through client's `User-Agent` header to upstream via `_build_upstream_headers`
- **Dev proxy mode**: already forwards all non-hop-by-hop headers (including `User-Agent`) — no change needed
- Remove `user_agent` parameter from `OptimizedHTTPSession`
- Remove hardcoded `User-Agent: argo-proxy/1.0` from model list fetching

### Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Client sends User-Agent | Overwritten with `argo-proxy/x.x.x` | Passed through as-is |
| Client omits User-Agent | `argo-proxy/x.x.x` sent | No User-Agent sent (aiohttp default) |
| Dev proxy mode | Session default leaked | Client's header forwarded |

## Test plan

- [x] Verified `_build_upstream_headers` includes client UA
- [x] Verified dev proxy `hop_by_hop` set does not include `user-agent`
- [x] No remaining `argo-proxy` User-Agent strings in codebase