### PR TITLE
feat: configurable default fallback model

### DIFF
--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -76,6 +76,10 @@ class ArgoConfig:
     # Model list auto-refresh
     model_refresh_interval_hours: float = 24  # 0 to disable
 
+    # Fallback models — used when an unrecognized model name is requested
+    default_chat_model: str = "argo:gpt-5.4-nano"
+    default_embed_model: str = "argo:text-embedding-3-small"
+
     # Image processing settings
     enable_payload_control: bool = False  # Enable automatic payload size control
     max_payload_size: int = 20  # MB default (total for all images)

--- a/src/argoproxy/models.py
+++ b/src/argoproxy/models.py
@@ -787,6 +787,10 @@ class ModelRegistry:
             default_model = self._config.default_embed_model
         else:
             default_model = self._config.default_chat_model
+            log_warning(
+                f"Unknown model_type '{model_type}', using chat fallback",
+                context="ModelRegistry",
+            )
         log_warning(
             f"Model '{model_name}' not found in registry, falling back to {default_model}",
             context="ModelRegistry",

--- a/src/argoproxy/models.py
+++ b/src/argoproxy/models.py
@@ -51,6 +51,7 @@ _DEFAULT_CHAT_MODELS = flatten_mapping(
         "gpt51": "argo:gpt-5.1",
         "gpt52": "argo:gpt-5.2",
         "gpt54": "argo:gpt-5.4",
+        "gpt54nano": "argo:gpt-5.4-nano",
         "gpt55": "argo:gpt-5.5",
         # gemini
         "gemini25pro": "argo:gemini-2.5-pro",
@@ -480,7 +481,7 @@ def _categorize_results(
             unavailable.clear()
         else:
             log_error(
-                "Proceeding without unavailable models. Subsequent calls to these models will be replaced with argo:gpt-5-nano",
+                "Proceeding without unavailable models. Subsequent calls to these models will use the configured default fallback",
                 context="models",
             )
 
@@ -781,14 +782,23 @@ class ModelRegistry:
             return model_name
 
         if model_type == "chat":
-            default_model = "argo:gpt-5-nano"
+            default_model = self._config.default_chat_model
         elif model_type == "embed":
-            default_model = "argo:text-embedding-3-small"
+            default_model = self._config.default_embed_model
+        else:
+            default_model = self._config.default_chat_model
         log_warning(
             f"Model '{model_name}' not found in registry, falling back to {default_model}",
             context="ModelRegistry",
         )
-        return self.available_models[default_model]
+        if default_model in self.available_models:
+            return self.available_models[default_model]
+        # Default model itself not in registry — return its name as-is
+        log_warning(
+            f"Default fallback model '{default_model}' not in registry either",
+            context="ModelRegistry",
+        )
+        return default_model
 
     def as_openai_list(self) -> dict[str, Any]:
         # Mock data for available models


### PR DESCRIPTION
## Summary

Make the fallback model for unrecognized requests configurable via the config file instead of hardcoded.

### Config

```yaml
default_chat_model: "argo:gpt-5.4-nano"    # default, was hardcoded "argo:gpt-5-nano"
default_embed_model: "argo:text-embedding-3-small"  # default, unchanged
```

### Changes

- Add `default_chat_model` and `default_embed_model` fields to `ArgoConfig`
- `ModelRegistry.resolve_model_name()` reads from config instead of hardcoded strings
- Graceful handling when the configured default model is not in the registry
- Add `gpt-5.4-nano` to the static default model list
- Remove hardcoded model name from log messages

### Why

Model names change frequently on the Argo side. Having the fallback model hardcoded means a code change + release for every rename. Config file lets operators update it without touching code.