### PR TITLE
feat: upgrade to llm-rosetta 0.9.0 — admin panel, unified transport, dev-mode fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ attack_logs/
 # Documentation worktrees (orphan branches)
 docs_en/
 docs_zh/
+# SQLite persistence (llm-rosetta gateway admin)
+data/
+gateway.db*

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -18,12 +18,12 @@ max_log_history: 3    # keep last N messages in verbose request logs
 #   - native_anthropic_base_url = {argo_base_url}
 #
 # Available environments:
-#   Production : https://apps.inside.anl.gov/argoapi
-#   Development: https://apps-dev.inside.anl.gov/argoapi   (default)
+#   Production : https://apps.inside.anl.gov/argoapi        (default)
+#   Development: https://apps-dev.inside.anl.gov/argoapi
 #   Test       : https://apps-test.inside.anl.gov/argoapi
 #
 # Switch with: argo-proxy config env prod|dev|test
-argo_base_url: https://apps-dev.inside.anl.gov/argoapi
+argo_base_url: https://apps.inside.anl.gov/argoapi
 
 # Network & validation
 connection_test_timeout: 5    # seconds per URL connectivity test at startup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ argo-proxy = "argoproxy.cli:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"argoproxy" = ["py.typed"]
+"argoproxy" = ["py.typed", "static/*.js", "static/*.css"]
 
 [tool.setuptools.dynamic]
 version = { attr = "argoproxy.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "llm-rosetta[gateway]>=0.8.3,<0.9.0",
+    "llm-rosetta[gateway]>=0.9.0",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",
     "tqdm>=4.67.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "llm-rosetta[gateway]>=0.9.0",
+    "llm-rosetta[gateway]>=0.9.0,<0.10.0",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",
     "tqdm>=4.67.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "llm-rosetta[gateway]>=0.8.2",
+    "llm-rosetta[gateway]>=0.8.3,<0.9.0",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",
     "tqdm>=4.67.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "llm-rosetta[gateway]>=0.7.1",
+    "llm-rosetta[gateway]>=0.8.2",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",
     "tqdm>=4.67.1",

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -557,7 +557,7 @@ async def handle_embeddings(request: Any) -> Response:
     url = f"{config.native_openai_base_url}/embeddings"
 
     try:
-        response = await transport.send_passthrough(
+        response = await transport.send(
             provider_info,
             url,
             body,

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -51,6 +51,7 @@ from .utils.misc import build_user_agent
 
 logger = logging.getLogger("argo-proxy")
 
+
 def _load_admin_custom_head() -> str:
     """Load admin panel customization from static resource files."""
     from pathlib import Path

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -51,56 +51,19 @@ from .utils.misc import build_user_agent
 
 logger = logging.getLogger("argo-proxy")
 
-_ADMIN_CUSTOM_HEAD = """\
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-  var _managed = {'argo-openai':1, 'argo-anthropic':1};
-  new MutationObserver(function(){
-    var cards = document.querySelectorAll('.provider-card');
-    if (!cards.length) return;
-    cards.forEach(function(card){
-      var nm = card.querySelector('.name');
-      if (!nm || nm.querySelector('.managed-badge')) return;
-      var pName = nm.textContent.trim();
-      if (!_managed[pName]) return;
-      var badge = document.createElement('span');
-      badge.className = 'managed-badge';
-      badge.style.cssText = 'font-size:11px;color:var(--text-dim);font-weight:400;margin-left:4px';
-      badge.textContent = '(managed)';
-      nm.appendChild(badge);
-      var toggle = card.querySelector('.toggle');
-      if (toggle) toggle.style.display = 'none';
-      var actions = card.querySelector('.actions');
-      if (actions) actions.style.display = 'none';
-    });
-    var addBtn = document.querySelector('button[onclick*="openProviderModal"]');
-    if (addBtn) addBtn.style.display = 'none';
-    // Inject "Refresh Models" button in Models tab
-    var fetchBtn = document.querySelector('button[onclick*="openFetchModelsModal"]');
-    if (fetchBtn && !document.getElementById('argoRefreshBtn')) {
-      var rb = document.createElement('button');
-      rb.id = 'argoRefreshBtn';
-      rb.className = 'btn btn-sm';
-      rb.style.cssText = 'margin-right:8px';
-      rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
-      rb.onclick = function(){
-        rb.disabled = true; rb.textContent = 'Refreshing...';
-        fetch('/refresh', {method:'POST'}).then(function(r){return r.json()}).then(function(d){
-          rb.disabled = false;
-          rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
-          if (typeof showToast==='function') showToast(d.after.total_aliases+' models ('+d.after.unique_models+' unique)','success');
-          if (typeof loadConfig==='function') loadConfig();
-        }).catch(function(){
-          rb.disabled = false;
-          rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
-          if (typeof showToast==='function') showToast('Refresh failed','error');
-        });
-      };
-      fetchBtn.parentNode.insertBefore(rb, fetchBtn);
-    }
-  }).observe(document.body, {childList: true, subtree: true});
-});
-</script>"""
+def _load_admin_custom_head() -> str:
+    """Load admin panel customization from static resource files."""
+    from pathlib import Path
+
+    static_dir = Path(__file__).parent / "static"
+    parts: list[str] = []
+    css_path = static_dir / "admin_custom.css"
+    if css_path.exists():
+        parts.append(f"<style>{css_path.read_text()}</style>")
+    js_path = static_dir / "admin_custom.js"
+    if js_path.exists():
+        parts.append(f"<script>{js_path.read_text()}</script>")
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -811,7 +774,7 @@ async def _startup(app: App) -> None:
         str(config_path) if config_path else None,
         config_io=config_io,
         disabled_tabs=["keys"],
-        custom_head=_ADMIN_CUSTOM_HEAD,
+        custom_head=_load_admin_custom_head(),
         branding={
             "title": "Argo Proxy",
             "subtitle": "gateway admin",

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -52,10 +52,16 @@ from .utils.misc import build_user_agent
 logger = logging.getLogger("argo-proxy")
 
 _ADMIN_CUSTOM_HEAD = """\
+<style>.tab[data-tab="keys"], #tab-keys { display: none !important; }</style>
 <script>
 document.addEventListener('DOMContentLoaded', function(){
   var _managed = {'argo-openai':1, 'argo-anthropic':1};
   new MutationObserver(function(){
+    // Disable API key fetching — argo-proxy has no gateway keystore
+    if (typeof loadKeys === 'function' && !loadKeys._disabled) {
+      loadKeys = function(){};
+      loadKeys._disabled = true;
+    }
     var cards = document.querySelectorAll('.provider-card');
     if (!cards.length) return;
     cards.forEach(function(card){

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -862,10 +862,27 @@ def create_app() -> App:
     register_admin_routes(app)
 
     if dev_mode:
+        from .dev_proxy import (
+            handle_dev_anthropic,
+            handle_dev_embeddings,
+            handle_dev_google,
+            handle_dev_models,
+            handle_dev_openai_chat,
+            handle_dev_openai_responses,
+        )
+
         log_warning(
             "Transparent proxy — all requests forwarded without conversion",
             context="app",
         )
+        app.route("/v1/chat/completions", methods=["POST"])(handle_dev_openai_chat)
+        app.route("/v1/responses", methods=["POST"])(handle_dev_openai_responses)
+        app.route("/v1/messages", methods=["POST"])(handle_dev_anthropic)
+        app.route("/v1beta/models/<path:model_path>", methods=["POST"])(
+            handle_dev_google
+        )
+        app.route("/v1/embeddings", methods=["POST"])(handle_dev_embeddings)
+        app.route("/v1/models", methods=["GET"])(handle_dev_models)
         app.route("/health", methods=["GET"])(handle_health)
         app.route("/version", methods=["GET"])(handle_version)
         app.route("/refresh", methods=["POST"])(handle_refresh_models)

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -12,6 +12,7 @@ import logging
 import os
 import signal
 import sys
+import time
 import uuid
 from typing import Any
 
@@ -50,6 +51,57 @@ from .utils.misc import build_user_agent
 
 logger = logging.getLogger("argo-proxy")
 
+_ADMIN_CUSTOM_HEAD = """\
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  var _managed = {'argo-openai':1, 'argo-anthropic':1};
+  new MutationObserver(function(){
+    var cards = document.querySelectorAll('.provider-card');
+    if (!cards.length) return;
+    cards.forEach(function(card){
+      var nm = card.querySelector('.name');
+      if (!nm || nm.querySelector('.managed-badge')) return;
+      var pName = nm.textContent.trim();
+      if (!_managed[pName]) return;
+      var badge = document.createElement('span');
+      badge.className = 'managed-badge';
+      badge.style.cssText = 'font-size:11px;color:var(--text-dim);font-weight:400;margin-left:4px';
+      badge.textContent = '(managed)';
+      nm.appendChild(badge);
+      var toggle = card.querySelector('.toggle');
+      if (toggle) toggle.style.display = 'none';
+      var actions = card.querySelector('.actions');
+      if (actions) actions.style.display = 'none';
+    });
+    var addBtn = document.querySelector('button[onclick*="openProviderModal"]');
+    if (addBtn) addBtn.style.display = 'none';
+    // Inject "Refresh Models" button in Models tab
+    var fetchBtn = document.querySelector('button[onclick*="openFetchModelsModal"]');
+    if (fetchBtn && !document.getElementById('argoRefreshBtn')) {
+      var rb = document.createElement('button');
+      rb.id = 'argoRefreshBtn';
+      rb.className = 'btn btn-sm';
+      rb.style.cssText = 'margin-right:8px';
+      rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
+      rb.onclick = function(){
+        rb.disabled = true; rb.textContent = 'Refreshing...';
+        fetch('/refresh', {method:'POST'}).then(function(r){return r.json()}).then(function(d){
+          rb.disabled = false;
+          rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
+          if (typeof showToast==='function') showToast(d.after.total_aliases+' models ('+d.after.unique_models+' unique)','success');
+          if (typeof loadConfig==='function') loadConfig();
+        }).catch(function(){
+          rb.disabled = false;
+          rb.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg> Refresh Models';
+          if (typeof showToast==='function') showToast('Refresh failed','error');
+        });
+      };
+      fetchBtn.parentNode.insertBefore(rb, fetchBtn);
+    }
+  }).observe(document.body, {childList: true, subtree: true});
+});
+</script>"""
+
 
 # ---------------------------------------------------------------------------
 # App state helpers
@@ -66,6 +118,68 @@ def _get_registry(app: App) -> ModelRegistry:
 
 def _get_gateway_config(app: App) -> Any:
     return app.gateway_config  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Telemetry — record metrics + request log for the admin dashboard
+# ---------------------------------------------------------------------------
+
+
+def _record_telemetry(
+    request: Any,
+    *,
+    model: str,
+    source_provider: ProviderType,
+    target_provider: ProviderType,
+    provider_name: str,
+    is_stream: bool,
+    status_code: int,
+    duration_ms: float,
+    error_detail: str | None,
+    profile: dict[str, Any] | None = None,
+) -> None:
+    metrics = getattr(request.app, "metrics", None)
+    if is_stream and metrics:
+        metrics.active_streams -= 1
+    if metrics:
+        metrics.record_request(
+            model=model,
+            source=source_provider,
+            target=target_provider,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            is_stream=is_stream,
+            provider_name=provider_name,
+            error_detail=error_detail,
+        )
+
+    request_log = getattr(request.app, "request_log", None)
+    if request_log is not None:
+        from llm_rosetta.observability import RequestLogEntry
+
+        entry = RequestLogEntry.create(
+            model=model,
+            source_provider=source_provider,
+            target_provider=target_provider,
+            target_provider_name=provider_name,
+            is_stream=is_stream,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            error_detail=error_detail,
+            client_ip=_extract_client_ip(request),
+            profile=profile,
+        )
+        request_log.add(entry)
+
+
+def _extract_client_ip(request: Any) -> str | None:
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        return xff.split(",")[0].strip()
+    addr = getattr(request, "client_addr", None)
+    if addr:
+        return str(addr[0])
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -175,8 +289,22 @@ async def _argo_proxy_handler(
     if ua:
         extra_headers["User-Agent"] = ua
 
+    if is_stream:
+        metrics = getattr(request.app, "metrics", None)
+        if metrics:
+            metrics.active_streams += 1
+
+    t0 = time.monotonic()
+    status_code = 500
+    error_detail: str | None = None
+    profile: dict[str, Any] | None = None
+    capture_state = getattr(request.app, "capture_state", None)
+    persistence = getattr(request.app, "persistence", None)
+    request_log = getattr(request.app, "request_log", None)
+
     try:
         if is_stream:
+            pre_entry_id = uuid.uuid4().hex
             response, profile = await handle_streaming(
                 route,
                 provider_info,
@@ -184,12 +312,16 @@ async def _argo_proxy_handler(
                 transport=transport,
                 metadata_store=store,
                 extra_headers=extra_headers,
+                capture_state=capture_state,
+                entry_id=pre_entry_id,
+                request_log=request_log,
             )
         elif (
             not is_stream
             and target_provider == "anthropic"
             and config.anthropic_stream_mode == "retry"
         ):
+            pre_entry_id = None
             response, profile = await _handle_with_retry(
                 route,
                 provider_info,
@@ -197,8 +329,11 @@ async def _argo_proxy_handler(
                 transport=transport,
                 metadata_store=store,
                 extra_headers=extra_headers,
+                capture_state=capture_state,
+                persistence=persistence,
             )
         else:
+            pre_entry_id = None
             response, profile = await handle_non_streaming(
                 route,
                 provider_info,
@@ -206,27 +341,54 @@ async def _argo_proxy_handler(
                 transport=transport,
                 metadata_store=store,
                 extra_headers=extra_headers,
+                capture_state=capture_state,
+                persistence=persistence,
             )
+
+        status_code = response.status_code
 
         # Check for ARGO auth warning in non-streaming responses
         if isinstance(response, Response) and hasattr(response, "body"):
             try:
                 resp_text = response.body.decode("utf-8", errors="replace")
                 if contains_argo_auth_warning(resp_text):
+                    status_code = 403
+                    error_detail = "ARGO authentication warning"
                     return argo_auth_error_response(source_provider)
             except Exception:
                 pass
+
+        if status_code >= 400 and hasattr(response, "body"):
+            error_detail = response.body.decode("utf-8", errors="replace")
 
         response.headers["x-request-id"] = request_id
         return response
 
     except ArgoAuthWarning:
+        status_code = 403
+        error_detail = "ARGO authentication warning"
         return argo_auth_error_response(source_provider)
-    except Exception:
+    except Exception as exc:
+        error_detail = str(exc)
         logger.exception("[%s] Proxy error", request_id)
+        status_code = 502
         resp = error_response_for_source(source_provider, 502, "Upstream error")
         resp.headers["x-request-id"] = request_id
         return resp
+    finally:
+        duration_ms = (time.monotonic() - t0) * 1000
+        _record_telemetry(
+            request,
+            model=model,
+            source_provider=source_provider,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
+            is_stream=is_stream,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            error_detail=error_detail,
+            profile=profile,
+        )
 
 
 async def _handle_with_retry(
@@ -237,6 +399,8 @@ async def _handle_with_retry(
     transport: Any,
     metadata_store: Any,
     extra_headers: dict[str, str] | None = None,
+    capture_state: Any | None = None,
+    persistence: Any | None = None,
 ) -> tuple[Response | StreamingResponse, dict[str, Any]]:
     """Try non-streaming, fall back to streaming on Anthropic bounce-back."""
     response, profile = await handle_non_streaming(
@@ -246,6 +410,8 @@ async def _handle_with_retry(
         transport=transport,
         metadata_store=metadata_store,
         extra_headers=extra_headers,
+        capture_state=capture_state,
+        persistence=persistence,
     )
 
     if response.status_code != 500 or not hasattr(response, "body"):
@@ -266,6 +432,7 @@ async def _handle_with_retry(
         transport=transport,
         metadata_store=metadata_store,
         extra_headers=extra_headers,
+        capture_state=capture_state,
     )
 
 
@@ -590,8 +757,8 @@ async def handle_version(request: Any) -> Response:
 
 async def _startup(app: App) -> None:
     """Initialize ARGO config, model registry, and transport."""
-    config_path = os.getenv("CONFIG_PATH")
-    config, _ = load_config(config_path, verbose=False)
+    config_path_env = os.getenv("CONFIG_PATH")
+    config, config_path = load_config(config_path_env, verbose=False)
     if config is None:
         log_error("Failed to load configuration", context="app")
         sys.exit(1)
@@ -635,8 +802,39 @@ async def _startup(app: App) -> None:
     # Admin panel state (metrics, request log, persistence, profiling)
     from llm_rosetta.gateway.admin import setup_admin
 
-    config_path_resolved = config_path if isinstance(config_path, str) else None
-    setup_admin(app, gateway_config, config_path_resolved)
+    from .config import ArgoConfigIO
+
+    config_io = ArgoConfigIO(config, registry)
+    setup_admin(
+        app,
+        gateway_config,
+        str(config_path) if config_path else None,
+        config_io=config_io,
+        custom_head=_ADMIN_CUSTOM_HEAD,
+        branding={
+            "title": "Argo Proxy",
+            "subtitle": "gateway admin",
+            "version": __version__,
+            "links": [
+                {
+                    "label": "GitHub",
+                    "url": "https://github.com/Oaklight/argo-proxy",
+                    "icon": "github",
+                },
+                {
+                    "label": "PyPI",
+                    "url": "https://pypi.org/project/argo-proxy/",
+                    "icon": "pypi",
+                },
+                {
+                    "label": "Docs",
+                    "url": "https://argo-proxy.readthedocs.io",
+                    "icon": "docs",
+                },
+            ],
+            "attribution": "Powered by llm-rosetta gateway",
+        },
+    )
 
     log_debug("Gateway transport initialized", context="app")
 
@@ -659,10 +857,11 @@ def create_app() -> App:
     internal_token = f"rsk-internal-{secrets.token_hex(16)}"
     admin_password = os.environ.get("ADMIN_PASSWORD")
     auth_state = AuthState(
-        frozenset(),  # no gateway-level API keys — ARGO validates upstream
+        None,  # no gateway-level keystore — ARGO validates upstream
         {},
         internal_token,
         admin_password=admin_password,
+        open_on_no_keys=True,  # ARGO validates upstream
     )
     app.auth_state = auth_state  # type: ignore[attr-defined]
     app.internal_token = internal_token  # type: ignore[attr-defined]
@@ -733,6 +932,8 @@ def create_app() -> App:
 
 async def _run_server(app: App, *, host: str, port: int, socket: str = "") -> None:
     await _startup(app)
+    app._bind_host = host  # type: ignore[attr-defined]
+    app._bind_port = port  # type: ignore[attr-defined]
     try:
         await app._serve(host, port, socket=socket or None)
     finally:

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -52,16 +52,10 @@ from .utils.misc import build_user_agent
 logger = logging.getLogger("argo-proxy")
 
 _ADMIN_CUSTOM_HEAD = """\
-<style>.tab[data-tab="keys"], #tab-keys { display: none !important; }</style>
 <script>
 document.addEventListener('DOMContentLoaded', function(){
   var _managed = {'argo-openai':1, 'argo-anthropic':1};
   new MutationObserver(function(){
-    // Disable API key fetching — argo-proxy has no gateway keystore
-    if (typeof loadKeys === 'function' && !loadKeys._disabled) {
-      loadKeys = function(){};
-      loadKeys._disabled = true;
-    }
     var cards = document.querySelectorAll('.provider-card');
     if (!cards.length) return;
     cards.forEach(function(card){
@@ -816,6 +810,7 @@ async def _startup(app: App) -> None:
         gateway_config,
         str(config_path) if config_path else None,
         config_io=config_io,
+        disabled_tabs=["keys"],
         custom_head=_ADMIN_CUSTOM_HEAD,
         branding={
             "title": "Argo Proxy",

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -616,6 +616,79 @@ async def handle_docs(request: Any) -> Response:
     return Response(body=html.encode(), status_code=200, content_type="text/html")
 
 
+async def handle_argo_env_get(request: Any) -> Response:
+    """Return the current ARGO environment and available options."""
+    from .config.model import ArgoConfig
+
+    config = _get_config(request.app)
+    current_url = config.argo_base_url
+    envs = ArgoConfig.ENVIRONMENTS
+    current_env = next((k for k, v in envs.items() if v == current_url), "custom")
+    return JSONResponse(
+        {"current": current_env, "url": current_url, "environments": envs}
+    )
+
+
+async def handle_argo_env_put(request: Any) -> Response:
+    """Switch the ARGO upstream environment with hot-reload."""
+    from .config.model import ArgoConfig
+
+    try:
+        body: dict[str, Any] = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    env_name = body.get("env", "").strip().lower()
+    custom_url = body.get("url", "").strip().rstrip("/")
+    envs = ArgoConfig.ENVIRONMENTS
+
+    if env_name == "custom":
+        if not custom_url or not custom_url.startswith(("http://", "https://")):
+            return JSONResponse(
+                {"error": "Custom environment requires a valid http(s) URL"},
+                status_code=400,
+            )
+        target_url = custom_url
+    elif env_name in envs:
+        target_url = envs[env_name]
+    else:
+        return JSONResponse(
+            {
+                "error": f"Unknown environment: '{env_name}'. "
+                f"Valid: {[*envs.keys(), 'custom']}"
+            },
+            status_code=400,
+        )
+
+    config = _get_config(request.app)
+
+    if config.argo_base_url == target_url:
+        return JSONResponse(
+            {"ok": True, "env": env_name, "url": target_url, "changed": False}
+        )
+
+    config_path = getattr(request.app, "config_path", None)
+    if not config_path:
+        return JSONResponse({"error": "No config path available"}, status_code=500)
+
+    config._argo_base_url = target_url
+    config._native_openai_base_url = ""
+    config._native_anthropic_base_url = ""
+
+    from .config.io import save_config as _save_config
+
+    _save_config(config, config_path)
+
+    registry = _get_registry(request.app)
+    request.app.gateway_config = build_gateway_config(config, registry)
+
+    log_info(f"Switched to '{env_name}' environment: {target_url}", context="app")
+
+    return JSONResponse(
+        {"ok": True, "env": env_name, "url": target_url, "changed": True}
+    )
+
+
 async def handle_health(request: Any) -> Response:
     return JSONResponse({"status": "healthy"})
 
@@ -861,6 +934,10 @@ def create_app() -> App:
 
     # Admin panel routes
     register_admin_routes(app)
+
+    # Argo-specific admin API
+    app.route("/admin/api/argo/env", methods=["GET"])(handle_argo_env_get)
+    app.route("/admin/api/argo/env", methods=["PUT"])(handle_argo_env_put)
 
     if dev_mode:
         from .dev_proxy import (

--- a/src/argoproxy/auth.py
+++ b/src/argoproxy/auth.py
@@ -13,7 +13,8 @@ import re
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
-from llm_rosetta.gateway.auth import api_key_label_var
+from llm_rosetta.gateway.auth import api_key_context_var
+from llm_rosetta.gateway.keystore import KeyContext
 
 _ARGO_AUTH_WARNING_PATTERN = re.compile(
     r"AUTHENTICATION NOTICE FROM ARGO", re.IGNORECASE
@@ -61,14 +62,16 @@ def create_argo_auth_hook() -> Any:
     """
 
     async def argo_auth_hook(request: Any) -> Response | None:
-        api_key_label_var.set(None)
+        api_key_context_var.set(None)
 
         if request.path in _PUBLIC_PATHS:
             return None
 
         key = _extract_api_key(request)
         if key:
-            api_key_label_var.set(key[:8] + "...")
+            api_key_context_var.set(
+                KeyContext(label=key[:8] + "...", allowed_shims=frozenset({"*"}))
+            )
         return None
 
     return argo_auth_hook

--- a/src/argoproxy/bridge.py
+++ b/src/argoproxy/bridge.py
@@ -59,14 +59,12 @@ def build_gateway_config(
 def _build_providers(config: ArgoConfig) -> dict:
     return {
         "argo-openai": {
-            "type": "argo-openai",
             "shim": "argo--openai_chat",
             "api_key": config.user,
             "base_url": config.native_openai_base_url,
             "readonly": True,
         },
         "argo-anthropic": {
-            "type": "argo-anthropic",
             "shim": "argo--anthropic",
             "api_key": config.user,
             "base_url": config.native_anthropic_base_url,

--- a/src/argoproxy/bridge.py
+++ b/src/argoproxy/bridge.py
@@ -59,22 +59,25 @@ def build_gateway_config(
 def _build_providers(config: ArgoConfig) -> dict:
     return {
         "argo-openai": {
-            "type": "openai_chat",
+            "type": "argo-openai",
             "shim": "argo--openai_chat",
             "api_key": config.user,
             "base_url": config.native_openai_base_url,
+            "readonly": True,
         },
         "argo-anthropic": {
-            "type": "anthropic",
+            "type": "argo-anthropic",
             "shim": "argo--anthropic",
             "api_key": config.user,
             "base_url": config.native_anthropic_base_url,
+            "readonly": True,
         },
     }
 
 
 def _build_models(registry: ModelRegistry) -> dict:
     """Map every model alias to a provider based on family classification."""
+    embed_models = set(registry.available_embed_models)
     models: dict = {}
     for alias, model_id in registry.available_models.items():
         family = classify_model_family(model_id)
@@ -82,13 +85,17 @@ def _build_models(registry: ModelRegistry) -> dict:
             provider_name = "argo-anthropic"
         else:
             provider_name = "argo-openai"
-        models[alias] = {
+        if alias in embed_models:
+            capabilities = ["embedding"]
+        else:
+            capabilities = ["text", "vision", "tools", "reasoning"]
+        entry: dict = {
             "provider": provider_name,
-            "upstream_model": model_id if model_id != alias else None,
+            "capabilities": capabilities,
         }
-        # strip None upstream_model to keep config clean
-        if models[alias]["upstream_model"] is None:
-            del models[alias]["upstream_model"]
+        if model_id != alias:
+            entry["upstream_model"] = model_id
+        models[alias] = entry
     return models
 
 

--- a/src/argoproxy/config/__init__.py
+++ b/src/argoproxy/config/__init__.py
@@ -1,11 +1,13 @@
 """Configuration subpackage: model, I/O, validation, and interactive helpers."""
 
+from .gateway_io import ArgoConfigIO
 from .interactive import _get_yes_no_input_with_timeout
 from .io import PATHS_TO_TRY, load_config, save_config, validate_config
 from .model import ArgoConfig
 
 __all__ = [
     "ArgoConfig",
+    "ArgoConfigIO",
     "PATHS_TO_TRY",
     "_get_yes_no_input_with_timeout",
     "load_config",

--- a/src/argoproxy/config/gateway_io.py
+++ b/src/argoproxy/config/gateway_io.py
@@ -44,17 +44,15 @@ class ArgoConfigIO:
         )
         return data
 
-    def load(self, path: str) -> dict[str, Any]:
-        from .io import load_config
-
-        raw, _ = load_config(path, as_is=True, verbose=False)
-        return self._inject_runtime_state(raw or {})
-
     def load_raw(self, path: str) -> dict[str, Any]:
         from .io import load_config
 
         raw, _ = load_config(path, as_is=True, verbose=False)
         return self._inject_runtime_state(raw or {})
+
+    # Gateway uses load_raw for admin API reads and load for hot-reload
+    # (_reload_gateway_config). In argo-proxy both behave the same.
+    load = load_raw
 
     def save(self, path: str, data: dict[str, Any]) -> None:
         data.pop("providers", None)

--- a/src/argoproxy/config/gateway_io.py
+++ b/src/argoproxy/config/gateway_io.py
@@ -1,0 +1,78 @@
+"""ConfigIO adapter that bridges ArgoConfig + ModelRegistry into the gateway admin panel."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..models.registry import ModelRegistry
+    from .model import ArgoConfig
+
+
+class ArgoConfigIO:
+    """ConfigIO implementation that injects runtime providers/models.
+
+    The gateway admin panel reads config via ``config_io.load_raw()`` and
+    writes via ``config_io.save()``.  argo-proxy's YAML has no ``providers``
+    or ``models`` sections — those are built at runtime from the ARGO
+    upstream.  This adapter injects them on read and strips them on write.
+
+    References are held (not copies), so model-registry refreshes are
+    reflected immediately.
+    """
+
+    def __init__(self, config: ArgoConfig, registry: ModelRegistry) -> None:
+        self._config = config
+        self._registry = registry
+
+    def _inject_runtime_state(self, data: dict[str, Any]) -> dict[str, Any]:
+        from ..bridge import _build_models, _build_providers
+
+        data["providers"] = _build_providers(self._config)
+        data["models"] = _build_models(self._registry)
+        data.setdefault("server", {}).update(
+            {"host": self._config.host, "port": self._config.port}
+        )
+        if self._config.socket:
+            data["server"]["socket"] = self._config.socket
+        data.setdefault("debug", {}).update(
+            {
+                "verbose": self._config.verbose,
+                "log_bodies": False,
+                "error_dumps": self._config.dump_requests,
+            }
+        )
+        return data
+
+    def load(self, path: str) -> dict[str, Any]:
+        from .io import load_config
+
+        raw, _ = load_config(path, as_is=True, verbose=False)
+        return self._inject_runtime_state(raw or {})
+
+    def load_raw(self, path: str) -> dict[str, Any]:
+        from .io import load_config
+
+        raw, _ = load_config(path, as_is=True, verbose=False)
+        return self._inject_runtime_state(raw or {})
+
+    def save(self, path: str, data: dict[str, Any]) -> None:
+        data.pop("providers", None)
+        data.pop("models", None)
+
+        # Map gateway-format nested keys back to flat ARGO keys
+        if server := data.pop("server", None):
+            if "host" in server:
+                data["host"] = server["host"]
+            if "port" in server:
+                data["port"] = server["port"]
+            if "socket" in server:
+                data["socket"] = server["socket"]
+        if debug := data.pop("debug", None):
+            if "verbose" in debug:
+                data["verbose"] = debug["verbose"]
+
+        from .io import _format_config_yaml
+
+        with open(path, "w") as f:
+            f.write(_format_config_yaml(data))

--- a/src/argoproxy/config/interactive.py
+++ b/src/argoproxy/config/interactive.py
@@ -193,7 +193,7 @@ def create_config(config_path: str | None = None) -> ArgoConfig:
 
     log_info("Creating new configuration...", context="config")
 
-    default_base = ArgoConfig._argo_dev_base
+    default_base = ArgoConfig._argo_prod_base
     while True:
         base_url = _get_base_url_input(default_base)
         log_info("Validating upstream connectivity...", context="config")

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -57,7 +57,7 @@ class ArgoConfig:
     _dev_mode: bool = False
 
     # Anthropic non-streaming request handling mode
-    _anthropic_stream_mode: str = "force"  # "force", "retry", or "passthrough"
+    _anthropic_stream_mode: str = "retry"  # "force", "retry", or "passthrough"
 
     # Debug request/response dumping
     _dump_requests: bool = False
@@ -175,15 +175,15 @@ class ArgoConfig:
         Returns:
             One of ``"force"``, ``"retry"``, or ``"passthrough"``.
 
-            - ``force``: Always force streaming upstream, aggregate back (default).
+            - ``force``: Always force streaming upstream, aggregate back.
             - ``retry``: Try non-streaming first, retry with streaming on
-              Anthropic's "streaming is required" bounce-back error.
+              Anthropic's "streaming is required" bounce-back error (default).
             - ``passthrough``: Never force streaming, pass through as-is.
         """
         valid = ("force", "retry", "passthrough")
         if self._anthropic_stream_mode in valid:
             return self._anthropic_stream_mode
-        return "force"
+        return "retry"
 
     @property
     def dump_requests(self) -> bool:
@@ -264,7 +264,7 @@ class ArgoConfig:
         # Persist optional flags only when set to non-default values
         if self._skip_url_validation:
             serialized["skip_url_validation"] = True
-        if self._anthropic_stream_mode != "force":
+        if self._anthropic_stream_mode != "retry":
             serialized["anthropic_stream_mode"] = self._anthropic_stream_mode
         if self._dump_requests:
             serialized["dump_requests"] = True

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -34,8 +34,7 @@ class ArgoConfig:
     user: str = ""
     verbose: bool = True
 
-    _argo_base_url: str = ""  # User-configurable base URL, overrides _argo_dev_base
-    _argo_dev_base: str = ENVIRONMENTS["dev"]
+    _argo_base_url: str = ""  # User-configurable base URL
     _argo_prod_base: str = ENVIRONMENTS["prod"]
 
     # Derived fields (to be constructed from base URL if not provided)
@@ -91,7 +90,7 @@ class ArgoConfig:
         """Get the effective Argo base URL (without trailing path segments)."""
         if self._argo_base_url:
             return self._argo_base_url.rstrip("/")
-        return self._argo_dev_base.rstrip("/")
+        return self._argo_prod_base.rstrip("/")
 
     # chat endpoint
     @property

--- a/src/argoproxy/dev_proxy.py
+++ b/src/argoproxy/dev_proxy.py
@@ -109,9 +109,14 @@ async def _raw_passthrough(
 
             if resp.status_code >= 400:
                 # Read error body and return as regular response
-                chunks: list[bytes] = []
-                async for chunk in resp.aiter_bytes():
-                    chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+                try:
+                    chunks: list[bytes] = []
+                    async for chunk in resp.aiter_bytes():
+                        chunks.append(
+                            chunk if isinstance(chunk, bytes) else chunk.encode()
+                        )
+                finally:
+                    await resp.aclose()
                 error_body = b"".join(chunks)
                 if contains_argo_auth_warning(
                     error_body.decode("utf-8", errors="replace")
@@ -137,6 +142,8 @@ async def _raw_passthrough(
                             yield chunk if isinstance(chunk, bytes) else chunk.encode()
                 except Exception:
                     logger.exception("[%s] Stream relay error", request_id)
+                finally:
+                    await resp.aclose()
 
             return StreamingResponse(
                 _relay(),

--- a/src/argoproxy/static/admin_custom.css
+++ b/src/argoproxy/static/admin_custom.css
@@ -1,0 +1,37 @@
+.managed-badge {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.argo-info-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-dim);
+  font-size: 13px;
+  cursor: default;
+  position: relative;
+}
+
+.argo-info-icon .hint-popup {
+  width: 320px;
+  white-space: normal;
+  pointer-events: auto;
+}
+
+/* Hover bridge: transparent hitbox between icon and popup (prevents hover gap) */
+.argo-info-icon .hint-popup::before {
+  content: "";
+  position: absolute;
+  bottom: -10px;
+  left: 0;
+  right: 0;
+  height: 10px;
+}
+
+.argo-info-icon .hint-popup a {
+  color: var(--accent);
+  text-decoration: underline;
+}

--- a/src/argoproxy/static/admin_custom.css
+++ b/src/argoproxy/static/admin_custom.css
@@ -35,3 +35,58 @@
   color: var(--accent);
   text-decoration: underline;
 }
+
+/* Environment switcher (inside Server Settings card) */
+.argo-env-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.env-btn-group {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.argo-env-btn {
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  border-right: 1px solid var(--border);
+}
+
+.argo-env-btn:last-child {
+  border-right: none;
+}
+
+.argo-env-btn:hover:not(.active):not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.argo-env-btn.active {
+  background: var(--accent, #3b82f6);
+  color: #fff;
+  font-weight: 600;
+}
+
+.argo-env-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.argo-env-url {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -1,0 +1,210 @@
+/**
+ * Argo-proxy admin panel customizations.
+ *
+ * Injected into the llm-rosetta gateway admin panel via custom_head.
+ * Uses MutationObserver to modify the DOM after the SPA renders.
+ *
+ * Features:
+ * - Managed provider badges and read-only enforcement
+ * - Info popup replacing "Add Provider" button
+ * - Read-only provider modal for managed providers
+ * - "Refresh Models" button in Models tab
+ */
+(function () {
+  "use strict";
+
+  var MANAGED = {
+    "argo-openai": "argo--openai_chat",
+    "argo-anthropic": "argo--anthropic",
+  };
+  var GATEWAY_DOCS =
+    "https://llm-rosetta.readthedocs.io/en/latest/gateway/";
+
+  // Track whether we've already injected the info icon and refresh button
+  var _infoInjected = false;
+  var _refreshInjected = false;
+
+  // --- Provider cards: managed badges + read-only actions ---
+
+  function patchProviderCards() {
+    var cards = document.querySelectorAll(".provider-card");
+    if (!cards.length) return;
+
+    cards.forEach(function (card) {
+      var nm = card.querySelector(".name");
+      if (!nm) return;
+      var pName = nm.textContent.replace(/\(managed\)/, "").trim();
+      if (!MANAGED[pName]) return;
+
+      // Add "(managed)" badge once
+      if (!nm.querySelector(".managed-badge")) {
+        var badge = document.createElement("span");
+        badge.className = "managed-badge";
+        badge.textContent = "(managed)";
+        nm.appendChild(badge);
+      }
+
+      // Hide toggle
+      var toggle = card.querySelector(".toggle");
+      if (toggle) toggle.style.display = "none";
+
+      // Actions: hide clone/delete, change Edit→View
+      var btns = card.querySelectorAll(".actions .btn");
+      btns.forEach(function (btn) {
+        var text = btn.textContent.trim();
+        if (text === "Clone" || text === "Delete" ||
+            text === "克隆" || text === "删除") {
+          btn.style.display = "none";
+        }
+        if (text === "Edit" || text === "编辑") {
+          btn.textContent = "View";
+        }
+      });
+    });
+  }
+
+  // --- Replace "Add Provider" with info icon ---
+
+  function patchAddProviderButton() {
+    if (_infoInjected) return;
+    var addBtn = document.querySelector(
+      'button[onclick*="openProviderModal()"]'
+    );
+    if (!addBtn) return;
+
+    var info = document.createElement("span");
+    info.id = "argoProviderInfo";
+    info.className = "hint-icon argo-info-icon";
+    info.innerHTML =
+      "?" +
+      '<span class="hint-popup">' +
+      "Providers in argo-proxy are managed automatically from the ARGO " +
+      "upstream and cannot be modified here.<br><br>" +
+      "For custom provider configuration, use " +
+      '<a href="' +
+      GATEWAY_DOCS +
+      '" target="_blank">llm-rosetta-gateway</a> directly.' +
+      "</span>";
+    addBtn.replaceWith(info);
+    _infoInjected = true;
+  }
+
+  // --- Provider modal: read-only for managed providers ---
+
+  function patchProviderModal() {
+    var modal = document.getElementById("providerModal");
+    if (!modal) return;
+    // Only patch when visible (gateway uses .open class)
+    if (!modal.classList.contains("open")) return;
+
+    var nameInput = document.getElementById("provName");
+    if (!nameInput) return;
+    var provName = nameInput.value.trim();
+    if (!MANAGED[provName]) return;
+
+    // Already patched this open
+    if (modal.dataset.argoPatched === provName) return;
+    modal.dataset.argoPatched = provName;
+
+    // Change title
+    var title = document.getElementById("providerModalTitle");
+    if (title) title.textContent = "View Provider";
+
+    // Fix Provider Type dropdown — set to the shim name
+    var typeSel = document.getElementById("provType");
+    var shimName = MANAGED[provName];
+    if (typeSel && shimName) {
+      typeSel.value = shimName;
+    }
+
+    // Make all inputs/selects read-only
+    modal.querySelectorAll("input, select, textarea").forEach(function (el) {
+      if (el.type === "checkbox") {
+        el.disabled = true;
+      } else {
+        el.readOnly = true;
+        el.disabled = true;
+      }
+    });
+
+    // Hide Save button (keep Cancel)
+    modal.querySelectorAll(".btn-primary").forEach(function (btn) {
+      btn.style.display = "none";
+    });
+  }
+
+  // Reset patched state when modal closes
+  function resetModalPatch() {
+    var modal = document.getElementById("providerModal");
+    if (!modal) return;
+    if (!modal.classList.contains("open")) {
+      delete modal.dataset.argoPatched;
+    }
+  }
+
+  // --- "Refresh Models" button in Models tab ---
+
+  function patchRefreshModels() {
+    if (_refreshInjected) return;
+    var fetchBtn = document.querySelector(
+      'button[onclick*="openFetchModelsModal"]'
+    );
+    if (!fetchBtn || document.getElementById("argoRefreshBtn")) return;
+
+    var rb = document.createElement("button");
+    rb.id = "argoRefreshBtn";
+    rb.className = "btn btn-sm";
+    rb.style.cssText = "margin-right:8px";
+
+    var refreshSvg =
+      '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+      'stroke-linejoin="round" style="vertical-align:-2px">' +
+      '<path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/>' +
+      '<path d="M2 11.5a10 10 0 0 1 18.8-4.3"/>' +
+      '<path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></svg>';
+
+    rb.innerHTML = refreshSvg + " Refresh Models";
+    rb.onclick = function () {
+      rb.disabled = true;
+      rb.textContent = "Refreshing...";
+      fetch("/refresh", { method: "POST" })
+        .then(function (r) {
+          return r.json();
+        })
+        .then(function (d) {
+          rb.disabled = false;
+          rb.innerHTML = refreshSvg + " Refresh Models";
+          if (typeof showToast === "function")
+            showToast(
+              d.after.total_aliases +
+                " models (" +
+                d.after.unique_models +
+                " unique)",
+              "success"
+            );
+          if (typeof loadConfig === "function") loadConfig();
+        })
+        .catch(function () {
+          rb.disabled = false;
+          rb.innerHTML = refreshSvg + " Refresh Models";
+          if (typeof showToast === "function")
+            showToast("Refresh failed", "error");
+        });
+    };
+    fetchBtn.parentNode.insertBefore(rb, fetchBtn);
+    _refreshInjected = true;
+  }
+
+  // --- Main observer ---
+
+  document.addEventListener("DOMContentLoaded", function () {
+    new MutationObserver(function () {
+      patchProviderCards();
+      patchAddProviderButton();
+      patchProviderModal();
+      resetModalPatch();
+      patchRefreshModels();
+    }).observe(document.body, { childList: true, subtree: true });
+  });
+})();

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -5,6 +5,7 @@
  * Uses MutationObserver to modify the DOM after the SPA renders.
  *
  * Features:
+ * - ARGO environment switcher in Server Settings
  * - Managed provider badges and read-only enforcement
  * - Info popup replacing "Add Provider" button
  * - Read-only provider modal for managed providers
@@ -20,9 +21,136 @@
   var GATEWAY_DOCS =
     "https://llm-rosetta.readthedocs.io/en/latest/gateway/";
 
-  // Track whether we've already injected the info icon and refresh button
+  // Track whether we've already injected widgets
+  var _envInjected = false;
   var _infoInjected = false;
   var _refreshInjected = false;
+
+  // --- ARGO environment switcher in Server Settings ---
+
+  function _getAdminHeaders() {
+    var h = { "Content-Type": "application/json" };
+    var token = sessionStorage.getItem("adminToken");
+    if (token) h["Authorization"] = "Bearer " + token;
+    return h;
+  }
+
+  function patchEnvSwitcher() {
+    if (_envInjected) return;
+    var serverCard = document.querySelector(
+      '#tab-providers .section .provider-card'
+    );
+    if (!serverCard) return;
+    if (document.getElementById("argoEnvSwitcher")) return;
+
+    var group = document.createElement("div");
+    group.className = "form-group";
+    group.id = "argoEnvSwitcher";
+    group.innerHTML =
+      '<label>ARGO Environment</label>' +
+      '<div class="argo-env-group">' +
+      '<div class="env-btn-group">' +
+      '<button class="argo-env-btn" data-env="prod">prod</button>' +
+      '<button class="argo-env-btn" data-env="dev">dev</button>' +
+      '<button class="argo-env-btn" data-env="test">test</button>' +
+      '<button class="argo-env-btn" data-env="custom">custom</button>' +
+      '</div>' +
+      '<span class="argo-env-url" id="argoEnvUrl"></span>' +
+      '</div>' +
+      '<div class="argo-env-custom" id="argoEnvCustom" style="display:none;margin-top:8px">' +
+      '<div style="display:flex;gap:8px">' +
+      '<input id="argoEnvCustomUrl" ' +
+      'style="flex:1;padding:6px 10px;background:var(--bg);border:1px solid var(--border);' +
+      'border-radius:6px;color:var(--text);font-size:12px">' +
+      '<button class="btn btn-primary btn-sm" id="argoEnvCustomSave">Apply</button>' +
+      '</div>' +
+      '</div>';
+
+    serverCard.insertBefore(group, serverCard.firstChild);
+    _envInjected = true;
+
+    _loadEnvState();
+
+    group.querySelectorAll(".argo-env-btn").forEach(function (btn) {
+      btn.onclick = function () {
+        if (btn.dataset.env === "custom") {
+          _showCustomInput(true);
+        } else {
+          _showCustomInput(false);
+          _switchEnv(btn.dataset.env);
+        }
+      };
+    });
+
+    document.getElementById("argoEnvCustomSave").onclick = function () {
+      var url = document.getElementById("argoEnvCustomUrl").value.trim();
+      if (!url) return;
+      _switchEnv("custom", url);
+    };
+  }
+
+  function _loadEnvState() {
+    fetch("/admin/api/argo/env", { headers: _getAdminHeaders() })
+      .then(function (r) { return r.json(); })
+      .then(function (d) { _updateEnvUI(d.current, d.url); })
+      .catch(function () { /* silent */ });
+  }
+
+  function _showCustomInput(show) {
+    var el = document.getElementById("argoEnvCustom");
+    if (el) el.style.display = show ? "block" : "none";
+  }
+
+  function _updateEnvUI(envName, envUrl) {
+    document.querySelectorAll(".argo-env-btn").forEach(function (b) {
+      b.classList.toggle("active", b.dataset.env === envName);
+      b.disabled = false;
+    });
+    var urlEl = document.getElementById("argoEnvUrl");
+    if (urlEl) urlEl.textContent = envUrl || "";
+    var isCustom = envName === "custom";
+    _showCustomInput(isCustom);
+    if (isCustom) {
+      var input = document.getElementById("argoEnvCustomUrl");
+      if (input) input.value = envUrl || "";
+    }
+  }
+
+  function _switchEnv(envName, customUrl) {
+    var btns = document.querySelectorAll(".argo-env-btn");
+    btns.forEach(function (b) { b.disabled = true; });
+
+    var payload = { env: envName };
+    if (customUrl) payload.url = customUrl;
+
+    fetch("/admin/api/argo/env", {
+      method: "PUT",
+      headers: _getAdminHeaders(),
+      body: JSON.stringify(payload),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        if (d.ok) {
+          _updateEnvUI(d.env, d.url);
+          if (typeof showToast === "function") {
+            showToast(
+              "Switched to " + d.env + (d.changed ? "" : " (already active)"),
+              "success"
+            );
+          }
+          if (d.changed && typeof loadConfig === "function") loadConfig();
+        } else {
+          btns.forEach(function (b) { b.disabled = false; });
+          if (typeof showToast === "function")
+            showToast(d.error || "Switch failed", "error");
+        }
+      })
+      .catch(function () {
+        btns.forEach(function (b) { b.disabled = false; });
+        if (typeof showToast === "function")
+          showToast("Environment switch failed", "error");
+      });
+  }
 
   // --- Provider cards: managed badges + read-only actions ---
 
@@ -204,6 +332,7 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     new MutationObserver(function () {
+      patchEnvSwitcher();
       patchProviderCards();
       patchAddProviderButton();
       patchProviderModal();

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -196,18 +196,13 @@
     _refreshInjected = true;
   }
 
-  // --- Page title ---
+  // --- Page title (run immediately, before DOMContentLoaded) ---
 
-  function patchPageTitle() {
-    if (document.title.indexOf("llm-rosetta") !== -1) {
-      document.title = document.title.replace("llm-rosetta Gateway", "Argo Proxy");
-    }
-  }
+  document.title = document.title.replace("llm-rosetta Gateway", "Argo Proxy");
 
   // --- Main observer ---
 
   document.addEventListener("DOMContentLoaded", function () {
-    patchPageTitle();
     new MutationObserver(function () {
       patchProviderCards();
       patchAddProviderButton();

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -196,9 +196,18 @@
     _refreshInjected = true;
   }
 
+  // --- Page title ---
+
+  function patchPageTitle() {
+    if (document.title.indexOf("llm-rosetta") !== -1) {
+      document.title = document.title.replace("llm-rosetta Gateway", "Argo Proxy");
+    }
+  }
+
   // --- Main observer ---
 
   document.addEventListener("DOMContentLoaded", function () {
+    patchPageTitle();
     new MutationObserver(function () {
       patchProviderCards();
       patchAddProviderButton();

--- a/src/argoproxy/transport.py
+++ b/src/argoproxy/transport.py
@@ -17,7 +17,6 @@ import re
 from collections.abc import AsyncIterator
 from typing import Any
 
-from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.gateway.transport._base import (
     UpstreamResponse,
     UpstreamStream,
@@ -101,20 +100,18 @@ class ArgoTransport:
         self._inner = inner
         self._anthropic_stream_mode = anthropic_stream_mode
 
-    async def send_request(
+    async def send(
         self,
         provider_info: ProviderInfo,
-        target_provider: ProviderType,
+        url: str,
         body: dict[str, Any],
-        model: str,
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> UpstreamResponse:
-        response = await self._inner.send_request(
+        response = await self._inner.send(
             provider_info,
-            target_provider,
+            url,
             body,
-            model,
             extra_headers=extra_headers,
         )
         _check_response_for_warning(response)
@@ -123,37 +120,18 @@ class ArgoTransport:
     async def send_streaming(
         self,
         provider_info: ProviderInfo,
-        target_provider: ProviderType,
+        url: str,
         body: dict[str, Any],
-        model: str,
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> UpstreamStream:
         stream = await self._inner.send_streaming(
             provider_info,
-            target_provider,
-            body,
-            model,
-            extra_headers=extra_headers,
-        )
-        return ArgoUpstreamStream(stream)
-
-    async def send_passthrough(
-        self,
-        provider_info: ProviderInfo,
-        url: str,
-        body: dict[str, Any],
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> UpstreamResponse:
-        response = await self._inner.send_passthrough(
-            provider_info,
             url,
             body,
             extra_headers=extra_headers,
         )
-        _check_response_for_warning(response)
-        return response
+        return ArgoUpstreamStream(stream)
 
     def raw_client(self, proxy_url: str | None = None) -> Any:
         """Return a raw :class:`AsyncClient` from the inner transport's pool.
@@ -171,9 +149,8 @@ class ArgoTransport:
     async def send_with_anthropic_retry(
         self,
         provider_info: ProviderInfo,
-        target_provider: ProviderType,
+        url: str,
         body: dict[str, Any],
-        model: str,
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> UpstreamResponse | UpstreamStream:
@@ -192,18 +169,16 @@ class ArgoTransport:
         if mode == "force":
             return await self.send_streaming(
                 provider_info,
-                target_provider,
+                url,
                 body,
-                model,
                 extra_headers=extra_headers,
             )
 
         # "passthrough" or "retry" — try non-streaming first
-        response = await self._inner.send_request(
+        response = await self._inner.send(
             provider_info,
-            target_provider,
+            url,
             body,
-            model,
             extra_headers=extra_headers,
         )
 
@@ -221,9 +196,8 @@ class ArgoTransport:
                 )
                 return await self.send_streaming(
                     provider_info,
-                    target_provider,
+                    url,
                     body,
-                    model,
                     extra_headers=extra_headers,
                 )
 


### PR DESCRIPTION
## Summary

- Upgrade llm-rosetta from 0.7.x to 0.9.0, pin upper bound <0.10.0
- Wire up gateway admin panel with Argo Proxy branding, managed provider UX, and custom CSS/JS
- Adapt ArgoTransport to llm-rosetta 0.9.0 unified transport API
- Migrate auth from `api_key_label_var` to `api_key_context_var`
- Fix dev-mode routing: restore dev_proxy route registrations accidentally removed in 9b05cc8, and change default `argo_base_url` fallback from apps-dev to production (Closes #152)

## Test plan

- [x] `ty check` passes (all pre-existing errors resolved by this branch)
- [x] `pytest tests/test_config_migrate.py tests/test_dev_proxy.py` — 22 passed
- [ ] Verify `--dev` mode routes requests to configured `argo_base_url`, not apps-dev
- [ ] Admin panel loads at `/admin` with correct branding
- [ ] Normal proxy mode unaffected (chat, embeddings, models endpoints)

Supersedes #151 (branch renamed from `worktree-bump-llm-rosetta-0.8.2`).