### PR TITLE
feat: upgrade to llm-rosetta 0.10.0 with preflight token count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "llm-rosetta[gateway]>=0.9.0,<0.10.0",
+    "llm-rosetta[gateway]>=0.10.0",
     "pydantic>=2.11.7",
     "tiktoken>=0.9.0",
     "tqdm>=4.67.1",

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -32,6 +32,7 @@ from llm_rosetta.gateway.proxy import (
     handle_non_streaming,
     handle_streaming,
 )
+from llm_rosetta.gateway.headers import get_preflight_tokens_override
 from llm_rosetta.gateway.transport.http import HttpTransport
 
 from .__init__ import __version__
@@ -269,6 +270,14 @@ async def _argo_proxy_handler(
     try:
         if is_stream:
             pre_entry_id = uuid.uuid4().hex
+
+            preflight_override = get_preflight_tokens_override(request)
+            preflight = (
+                preflight_override
+                if preflight_override is not None
+                else route.preflight_token_count
+            )
+
             response, profile = await handle_streaming(
                 route,
                 provider_info,
@@ -279,6 +288,7 @@ async def _argo_proxy_handler(
                 capture_state=capture_state,
                 entry_id=pre_entry_id,
                 request_log=request_log,
+                preflight_token_count=preflight,
             )
         elif (
             not is_stream
@@ -908,6 +918,10 @@ def create_app() -> App:
     app.before_request(create_argo_auth_hook())
     if admin_password:
         app.before_request(create_auth_hook(auth_state))
+
+    # NOTE: llm-rosetta gateway provides rate limiting middleware
+    # (RateLimitState) but argo-proxy does not enable it — ARGO's upstream
+    # already enforces rate limits per-user.
 
     # Security middleware
     from .utils.attack_logger import create_security_hook

--- a/src/argoproxy/config/gateway_io.py
+++ b/src/argoproxy/config/gateway_io.py
@@ -19,6 +19,11 @@ class ArgoConfigIO:
 
     References are held (not copies), so model-registry refreshes are
     reflected immediately.
+
+    NOTE: This class does NOT inherit from
+    :class:`llm_rosetta.gateway.config.JsoncConfigIO`, so the gateway's
+    automatic config migration framework is not applied.  argo-proxy
+    manages its own YAML config format separately.
     """
 
     def __init__(self, config: ArgoConfig, registry: ModelRegistry) -> None:

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -234,6 +234,7 @@
     modal.dataset.argoPatched = provName;
 
     // Lock provider name (identity — cannot be renamed)
+    nameInput.readOnly = true;
     nameInput.disabled = true;
 
     // Lock provider type dropdown and set to the shim name

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -161,7 +161,9 @@
     cards.forEach(function (card) {
       var nm = card.querySelector(".name");
       if (!nm) return;
-      var pName = nm.textContent.replace(/\(managed\)/, "").trim();
+      var pName = (nm.firstChild && nm.firstChild.nodeType === 3)
+        ? nm.firstChild.textContent.trim()
+        : nm.textContent.replace(/\(managed\)/, "").trim();
       if (!MANAGED[pName]) return;
 
       // Add "(managed)" badge once
@@ -176,16 +178,13 @@
       var toggle = card.querySelector(".toggle");
       if (toggle) toggle.style.display = "none";
 
-      // Actions: hide clone/delete, change Edit→View
+      // Actions: hide clone/delete (Edit stays — settings are adjustable)
       var btns = card.querySelectorAll(".actions .btn");
       btns.forEach(function (btn) {
         var text = btn.textContent.trim();
         if (text === "Clone" || text === "Delete" ||
             text === "克隆" || text === "删除") {
           btn.style.display = "none";
-        }
-        if (text === "Edit" || text === "编辑") {
-          btn.textContent = "View";
         }
       });
     });
@@ -217,7 +216,7 @@
     _infoInjected = true;
   }
 
-  // --- Provider modal: read-only for managed providers ---
+  // --- Provider modal: lock identity fields for managed providers ---
 
   function patchProviderModal() {
     var modal = document.getElementById("providerModal");
@@ -234,31 +233,17 @@
     if (modal.dataset.argoPatched === provName) return;
     modal.dataset.argoPatched = provName;
 
-    // Change title
-    var title = document.getElementById("providerModalTitle");
-    if (title) title.textContent = "View Provider";
+    // Lock provider name (identity — cannot be renamed)
+    nameInput.readOnly = true;
+    nameInput.disabled = true;
 
-    // Fix Provider Type dropdown — set to the shim name
+    // Lock provider type dropdown and set to the shim name
     var typeSel = document.getElementById("provType");
     var shimName = MANAGED[provName];
     if (typeSel && shimName) {
       typeSel.value = shimName;
+      typeSel.disabled = true;
     }
-
-    // Make all inputs/selects read-only
-    modal.querySelectorAll("input, select, textarea").forEach(function (el) {
-      if (el.type === "checkbox") {
-        el.disabled = true;
-      } else {
-        el.readOnly = true;
-        el.disabled = true;
-      }
-    });
-
-    // Hide Save button (keep Cancel)
-    modal.querySelectorAll(".btn-primary").forEach(function (btn) {
-      btn.style.display = "none";
-    });
   }
 
   // Reset patched state when modal closes

--- a/src/argoproxy/static/admin_custom.js
+++ b/src/argoproxy/static/admin_custom.js
@@ -234,7 +234,6 @@
     modal.dataset.argoPatched = provName;
 
     // Lock provider name (identity — cannot be renamed)
-    nameInput.readOnly = true;
     nameInput.disabled = true;
 
     // Lock provider type dropdown and set to the shim name


### PR DESCRIPTION
## Summary

- Bump `llm-rosetta[gateway]` dependency from `>=0.9.0,<0.10.0` to `>=0.10.0` (no upper bound)
- Wire **preflight token count** into the streaming proxy path — supports per-provider config (toggleable in admin panel) and per-request override via `X-Rosetta-Preflight-Tokens` header
- Fix admin panel compatibility with llm-rosetta 0.10.0 (capability badges changed `.name` element structure)
- Allow editing managed provider settings (preflight, hoist, timeout, URL templates, etc.) — only lock provider name and type, keeping Clone/Delete hidden
- Document that rate limiting middleware and config migration framework from llm-rosetta are intentionally not enabled

## What's new in llm-rosetta 0.10.0 (relevant to argo-proxy)

| Feature | Auto-effective | Needs opt-in |
|---------|:-:|:-:|
| Credential sanitization in error responses | ✅ | |
| Upstream redirect blocking (security) | ✅ | |
| Admin UI improvements (modular CSS/JS, error dumps, cleanup) | ✅ | |
| Preflight token count for accurate streaming input_tokens | | ✅ (this PR) |
| Rate limiting middleware | | ❌ (not applicable — ARGO enforces upstream) |
| Config migration framework | | ❌ (not applicable — argo-proxy uses YAML) |

## Test plan

- [x] All imports verified with llm-rosetta 0.10.0
- [x] Admin panel tested via Playwright: managed provider cards show `(managed)` badge, Edit opens modal with name/type locked, other settings editable including preflight toggle, Save works
- [ ] Smoke test streaming request with `X-Rosetta-Preflight-Tokens: true` header