### PR TITLE
chore: remove embedding_path hack (llm-rosetta normalizes base_url)

### DIFF
--- a/src/argoproxy/bridge.py
+++ b/src/argoproxy/bridge.py
@@ -64,7 +64,6 @@ def _build_providers(config: ArgoConfig) -> dict:
             "base_url": config.native_openai_base_url,
             "readonly": True,
             "embedding_format": "openai",
-            "embedding_path": "/embeddings",
         },
         "argo-anthropic": {
             "shim": "argo--anthropic",


### PR DESCRIPTION
## Summary

- Remove `"embedding_path": "/embeddings"` workaround from `bridge.py`
- llm-rosetta's `normalize_base_url` (merged in Oaklight/llm-rosetta#588) now auto-detects and strips duplicate version prefixes, so the hack is no longer needed
- Default `/v1/embeddings` path works correctly with `base_url` ending in `/v1`

One-line deletion.

## Test plan

- [ ] 34 argo-proxy tests pass
- [ ] Lint clean