### PR TITLE
fix: add error dumps for transport-level exceptions

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -338,36 +338,42 @@ async def _argo_proxy_handler(
         response.headers["x-request-id"] = request_id
         return response
 
-    except ArgoAuthWarning:
+    except ArgoAuthWarning as warn:
         status_code = 403
-        error_detail = "ARGO authentication warning"
-        dump_error(
-            persistence,
-            request_body=body,
-            response_text=error_detail,
-            model=model,
-            source_provider=source_provider,
-            target_provider=route.target_provider,
-            provider_name=route.provider_name,
-            status_code=403,
-            error_phase="transport",
-        )
+        error_detail = str(warn)
+        try:
+            dump_error(
+                persistence,
+                request_body=body,
+                response_text=error_detail,
+                model=model,
+                source_provider=source_provider,
+                target_provider=route.target_provider,
+                provider_name=route.provider_name,
+                status_code=403,
+                error_phase="transport",
+            )
+        except Exception as e:
+            logger.debug("dump_error failed: %s", e)
         return argo_auth_error_response(source_provider)
     except Exception as exc:
         error_detail = str(exc)
         logger.exception("[%s] Proxy error", request_id)
         status_code = 502
-        dump_error(
-            persistence,
-            request_body=body,
-            response_text=error_detail,
-            model=model,
-            source_provider=source_provider,
-            target_provider=route.target_provider,
-            provider_name=route.provider_name,
-            status_code=502,
-            error_phase="transport",
-        )
+        try:
+            dump_error(
+                persistence,
+                request_body=body,
+                response_text=error_detail,
+                model=model,
+                source_provider=source_provider,
+                target_provider=route.target_provider,
+                provider_name=route.provider_name,
+                status_code=502,
+                error_phase="transport",
+            )
+        except Exception as e:
+            logger.debug("dump_error failed: %s", e)
         resp = error_response_for_source(source_provider, 502, "Upstream error")
         resp.headers["x-request-id"] = request_id
         return resp

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -34,6 +34,7 @@ from llm_rosetta.gateway.proxy import (
 )
 from llm_rosetta.gateway.headers import get_preflight_tokens_override
 from llm_rosetta.gateway.transport.http import HttpTransport
+from llm_rosetta.observability.error_dump import dump_error
 
 from .__init__ import __version__
 from .auth import (
@@ -340,11 +341,33 @@ async def _argo_proxy_handler(
     except ArgoAuthWarning:
         status_code = 403
         error_detail = "ARGO authentication warning"
+        dump_error(
+            persistence,
+            request_body=body,
+            response_text=error_detail,
+            model=model,
+            source_provider=source_provider,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
+            status_code=403,
+            error_phase="transport",
+        )
         return argo_auth_error_response(source_provider)
     except Exception as exc:
         error_detail = str(exc)
         logger.exception("[%s] Proxy error", request_id)
         status_code = 502
+        dump_error(
+            persistence,
+            request_body=body,
+            response_text=error_detail,
+            model=model,
+            source_provider=source_provider,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
+            status_code=502,
+            error_phase="transport",
+        )
         resp = error_response_for_source(source_provider, 502, "Upstream error")
         resp.headers["x-request-id"] = request_id
         return resp


### PR DESCRIPTION
Closes #160

## Summary

- Added `dump_error()` calls in argo-proxy's top-level exception handlers in `_argo_proxy_handler` so that `ArgoAuthWarning` (403) and generic transport exceptions (502) are recorded in the admin Error Dumps tab.
- Previously these exceptions were logged via `logger.exception()` and recorded in the request log, but never dumped via `dump_error()`, making them invisible in the Error Dumps UI.
- Follows the same pattern used by llm-rosetta's gateway in its own `_proxy_handler` except block.

## Test plan

- [ ] Trigger an `ArgoAuthWarning` (e.g. expired ARGO credentials) and verify the error appears in the admin Error Dumps tab
- [ ] Trigger a transport-level exception (e.g. unreachable upstream) and verify it also appears in Error Dumps
- [ ] Confirm existing request log and metrics recording still works as before