### PR TITLE
fix: show username instead of truncated API key in admin logs

### DIFF
--- a/src/argoproxy/auth.py
+++ b/src/argoproxy/auth.py
@@ -69,8 +69,15 @@ def create_argo_auth_hook() -> Any:
 
         key = _extract_api_key(request)
         if key:
+            if should_use_username_passthrough():
+                # Key IS the ANL username; show it in full.
+                label = key
+            else:
+                # Use the configured ARGO username when available.
+                argo_cfg = getattr(request.app, "argo_config", None)
+                label = getattr(argo_cfg, "user", None) or key[:8] + "..."
             api_key_context_var.set(
-                KeyContext(label=key[:8] + "...", allowed_shims=frozenset({"*"}))
+                KeyContext(label=label, allowed_shims=frozenset({"*"}))
             )
         return None
 

--- a/src/argoproxy/auth.py
+++ b/src/argoproxy/auth.py
@@ -75,7 +75,10 @@ def create_argo_auth_hook() -> Any:
             else:
                 # Use the configured ARGO username when available.
                 argo_cfg = getattr(request.app, "argo_config", None)
-                label = getattr(argo_cfg, "user", None) or key[:8] + "..."
+                configured_user = getattr(argo_cfg, "user", None)
+                label = (
+                    configured_user if configured_user is not None else key[:8] + "..."
+                )
             api_key_context_var.set(
                 KeyContext(label=label, allowed_shims=frozenset({"*"}))
             )


### PR DESCRIPTION
## Summary

- Display the actual username in admin log entries instead of a truncated API key prefix (`key[:8]...`)
- When `--username-passthrough` is enabled, the API key IS the ANL username — show it in full
- When passthrough is disabled, use the configured ARGO username (`config.user`) from the app context
- Falls back to the old truncated label only if config is not yet available (during startup)

Closes #159

## Test plan

- [ ] Start argo-proxy with `--username-passthrough` enabled, make requests, verify the Logs tab shows the full username
- [ ] Start argo-proxy without `--username-passthrough`, make requests, verify the Logs tab shows the configured ANL username
- [ ] Verify no regressions in log display for public health/version endpoints (no label shown)