### PR TITLE
fix: restore per-request user tagging in CLI logs

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -47,7 +47,14 @@ from .bridge import build_gateway_config, rebuild_gateway_models
 from .config import load_config
 from .models import ModelRegistry
 from .transport import ArgoAuthWarning, ArgoTransport
-from .utils.logging import log_debug, log_error, log_info, log_warning
+from .utils.logging import (
+    clear_request_user,
+    log_debug,
+    log_error,
+    log_info,
+    log_warning,
+    set_request_user,
+)
 from .utils.misc import build_user_agent
 
 logger = logging.getLogger("argo-proxy")
@@ -218,6 +225,9 @@ async def _argo_proxy_handler(
             body["user"] = api_key
     else:
         body["user"] = config.user
+
+    # Tag CLI log lines with the resolved user (contextvar-based)
+    user_token = set_request_user(body.get("user", ""))
 
     # Anthropic metadata.user_id injection
     if target_provider == "anthropic":
@@ -391,6 +401,8 @@ async def _argo_proxy_handler(
             error_detail=error_detail,
             profile=profile,
         )
+        if user_token is not None:
+            clear_request_user(user_token)
 
 
 async def _handle_with_retry(

--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -172,6 +172,7 @@ async def _argo_proxy_handler(
 
     request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
 
+    user_token = None
     try:
         body: dict[str, Any] = request.json()
     except Exception:


### PR DESCRIPTION
## Summary

- Restores `set_request_user` / `clear_request_user` calls that were dropped during the v3.3.0 refactor when request handling moved from `endpoints/dispatch.py` to `app.py`
- The contextvar infrastructure in `utils/logging.py` was intact but never set, so all CLI log lines were missing `user=xxx` tags
- Adds the call after the user field is resolved (username passthrough or config fallback) and clears it in the `finally` block

Closes #163

## Test plan

- [x] All existing tests pass (34/34)
- [x] Module imports verified
- [x] `set_request_user` / `clear_request_user` round-trip verified
- [ ] Manual verification: start argo-proxy, send a request, confirm log lines show `user=xxx`