### PR TITLE
fix: downgrade custom tools to functions on the argo-openai provider

### DIFF
--- a/src/argoproxy/bridge.py
+++ b/src/argoproxy/bridge.py
@@ -64,6 +64,21 @@ def _build_providers(config: ArgoConfig) -> dict:
             "base_url": config.native_openai_base_url,
             "readonly": True,
             "embedding_format": "openai",
+            # ARGO's OpenAI upstream caps `tools[].custom.description` at 4096
+            # characters, which Codex's Code Mode `exec` tool blows past (~12-13k).
+            # Function tools carry no such cap, so let llm-rosetta downgrade
+            # custom tools to functions; the response path restores the original
+            # type from metadata, so clients still see `custom_tool_call`.
+            #
+            # Note this is a blanket downgrade: it applies to *every* custom
+            # tool, not just oversized ones, so a small custom tool loses its
+            # grammar constraint unnecessarily. A length-aware downgrade would
+            # be more correct but needs the threshold plumbed into llm-rosetta;
+            # not worth it while `exec` is the only custom tool in play.
+            #
+            # Revert this once ARGO lifts the 4096 cap — the constraint is
+            # theirs, not llm-rosetta's.
+            "supports_custom_tools": False,
         },
         "argo-anthropic": {
             "shim": "argo--anthropic",


### PR DESCRIPTION
## Problem

ARGO's OpenAI upstream rejects `tools[].custom.description` longer than 4096 characters with `string_above_max_length`. Codex's Code Mode `exec` tool carries a 10.5k–13.5k character description (the JS bridge API doc), so every Code Mode request to a `-sol` model fails outright.

Verified against the live upstream that the cap is specific to `custom` tools:

| tool type | description length | result |
|---|---|---|
| `custom` | 13457 | rejected |
| `custom` | 4096 | accepted |
| `function` | 13457 | accepted |

Truncating the description is **not** a safe workaround. With the instructions cut off, the model emits garbage into the tool input (`const matches = ALL_TOOLS.filter(...)`) instead of a shell command — it silently corrupts the tool contract rather than failing loudly.

## Change

Set `supports_custom_tools: False` on the `argo-openai` provider so llm-rosetta rewrites custom tools as function tools on the way out. The response path restores the original type from `metadata["_downgraded_from"]`, so clients still see `custom_tool_call`.

The comment block records why, including that this is a blanket downgrade rather than a length-aware one, and that it should be reverted once ARGO lifts the cap — the constraint is theirs, not llm-rosetta's.

## Dependency

Requires an llm-rosetta build where `supports_custom_tools` is a tri-state (`bool | None`) — Oaklight/llm-rosetta#624. Before that fix, an explicit `False` was indistinguishable from unset and lost to the shim default, making this setting inert. **The `llm-rosetta[gateway]>=0.11.2` pin in `pyproject.toml` needs bumping once that release lands**; I left it alone since there is no version to pin to yet. This PR should not merge before then, or the flag will land as a no-op.

Related: Oaklight/llm-rosetta#623 fixes a separate converter gap on the same Codex path (tools nested in `additional_tools` never reaching the IR).

## Scope note

The trigger is the **model slug**, not the Codex CLI version. Bisected across 0.144.5 → 0.148.0: with the same binary and config, `gpt-5.4`/`gpt-5.5`/`gpt-5.6` send 10–14 top-level tools and no custom tool, while `gpt-5.6-sol` sends a 10495-char custom `exec`. `gpt-5.5` therefore works fine against an unpatched proxy; this only matters for `-sol` models.

## Verification

`test/` results are identical to master's baseline (31 failed / 10 passed — those tests require live upstream config, and two modules fail to import on master already, referencing `argoproxy.endpoints.dispatch` and `argoproxy.tool_calls.leaked_tool_parser`, neither of which exists). No regression from this change.

---

*Developed with assistance from Claude Code; all changes reviewed and tested by me.*