### PR TITLE
feat: add --data-dir support for runtime data directory

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -826,12 +826,14 @@ async def _startup(app: App) -> None:
     from .config import ArgoConfigIO
 
     config_io = ArgoConfigIO(config, registry)
+    resolved_data_dir = config.data_dir or None
     setup_admin(
         app,
         gateway_config,
         str(config_path) if config_path else None,
         config_io=config_io,
         disabled_tabs=["keys"],
+        data_dir=resolved_data_dir,
         custom_head=_load_admin_custom_head(),
         branding={
             "title": "Argo Proxy",

--- a/src/argoproxy/bridge.py
+++ b/src/argoproxy/bridge.py
@@ -52,6 +52,8 @@ def build_gateway_config(
     }
     if argo_config.socket:
         raw["server"]["socket"] = argo_config.socket
+    if argo_config.data_dir:
+        raw["server"]["data_dir"] = argo_config.data_dir
 
     return GatewayConfig(raw)
 

--- a/src/argoproxy/cli/handlers.py
+++ b/src/argoproxy/cli/handlers.py
@@ -46,6 +46,8 @@ def set_config_envs(args: argparse.Namespace):
         os.environ["DUMP_REQUESTS"] = str(True)
     if args.dump_dir:
         os.environ["DUMP_DIR"] = args.dump_dir
+    if getattr(args, "data_dir", None):
+        os.environ["DATA_DIR"] = args.data_dir
 
 
 def handle_serve(args: argparse.Namespace):
@@ -76,6 +78,10 @@ def handle_serve(args: argparse.Namespace):
 
         if config_path is not None:
             get_attack_logger().set_config_path(config_path)
+
+        data_dir = config_instance.data_dir
+        if data_dir:
+            get_attack_logger().set_data_dir(Path(data_dir))
 
         if config_instance.socket:
             log_info(
@@ -393,7 +399,9 @@ _DIAGNOSTIC_LOG_TYPES: dict[str, tuple[str, list[str]]] = {
 
 
 def _collect_diagnostic_logs(
-    config_path: str | None = None, log_type: str = "all"
+    config_path: str | None = None,
+    log_type: str = "all",
+    data_dir: str | None = None,
 ) -> None:
     """Collect diagnostic logs into a tar.gz archive.
 
@@ -401,14 +409,22 @@ def _collect_diagnostic_logs(
         config_path: Optional explicit path to the config file.
         log_type: Type of logs to collect. One of the keys in
             ``_DIAGNOSTIC_LOG_TYPES`` or ``"all"``.
+        data_dir: Optional explicit data directory. When set, diagnostic
+            logs are looked up here instead of next to the config file.
     """
     import tarfile
     from datetime import datetime
 
     from ..config import load_config
 
-    _, actual_config_path = load_config(config_path, verbose=False)
-    base_dir = actual_config_path.parent if actual_config_path else Path.cwd()
+    config, actual_config_path = load_config(config_path, verbose=False)
+
+    if data_dir:
+        base_dir = Path(data_dir)
+    elif config and config.data_dir:
+        base_dir = Path(config.data_dir)
+    else:
+        base_dir = actual_config_path.parent if actual_config_path else Path.cwd()
 
     # Determine which log types to collect
     if log_type == "all":
@@ -474,7 +490,11 @@ def handle_logs(args: argparse.Namespace):
     config_path = getattr(args, "config", None)
 
     if args.logs_action == "collect":
-        _collect_diagnostic_logs(config_path, log_type=getattr(args, "type", "all"))
+        _collect_diagnostic_logs(
+            config_path,
+            log_type=getattr(args, "type", "all"),
+            data_dir=getattr(args, "data_dir", None),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/argoproxy/cli/parser.py
+++ b/src/argoproxy/cli/parser.py
@@ -113,6 +113,16 @@ def _add_serve_arguments(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory for runtime data (gateway.db, attack_logs, etc.).\n"
+            "Overrides the data_dir setting in the config file.\n"
+            "(default: data/ next to config file)"
+        ),
+    )
+    parser.add_argument(
         "--dev",
         action="store_true",
         default=False,
@@ -184,6 +194,12 @@ def _add_logs_subparsers(parser: argparse.ArgumentParser) -> None:
     )
     collect_parser.add_argument(
         "config", nargs="?", default=None, help="Config file path"
+    )
+    collect_parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=None,
+        help="Directory containing runtime data (overrides config-relative default)",
     )
     collect_parser.add_argument(
         "--type",

--- a/src/argoproxy/config/io.py
+++ b/src/argoproxy/config/io.py
@@ -165,6 +165,9 @@ def _apply_env_overrides(config_data: ArgoConfig) -> ArgoConfig:
     if env_dump_dir := os.getenv("DUMP_DIR"):
         config_data._dump_dir = env_dump_dir
 
+    if env_data_dir := os.getenv("DATA_DIR"):
+        config_data._data_dir = env_data_dir
+
     return config_data
 
 

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -222,22 +222,13 @@ class ArgoConfig:
     def data_dir(self) -> str:
         """Directory for runtime data (gateway.db, attack_logs, etc.).
 
-        Resolution order:
-        1. Explicitly configured ``_data_dir`` value.
-        2. ``data/`` subdirectory next to the config file (if CONFIG_PATH
-           is set).
-        3. Empty string (let downstream code decide the default).
+        Returns the explicitly configured value (from ``--data-dir`` CLI
+        flag, ``DATA_DIR`` env var, or ``data_dir`` config field), or an
+        empty string when not set.  An empty string lets downstream code
+        (llm-rosetta ``setup_admin``, ``AttackLogger``) fall back to
+        their own defaults, preserving backward compatibility.
         """
-        import os
-
-        if self._data_dir:
-            return self._data_dir
-        config_path = os.environ.get("CONFIG_PATH")
-        if config_path:
-            from pathlib import Path
-
-            return str(Path(config_path).parent / "data")
-        return ""
+        return self._data_dir
 
     @classmethod
     def from_dict(cls, config_dict: dict):

--- a/src/argoproxy/config/model.py
+++ b/src/argoproxy/config/model.py
@@ -62,6 +62,9 @@ class ArgoConfig:
     _dump_requests: bool = False
     _dump_dir: str = ""
 
+    # Runtime data directory (attack_logs, gateway.db, etc.)
+    _data_dir: str = ""
+
     # Validation and resolver settings
     _skip_url_validation: bool = False
     _user_validated: bool = False  # Set after upstream user validation passes
@@ -215,6 +218,27 @@ class ArgoConfig:
             return str(Path(config_path).parent / "dumps")
         return "/tmp/argo_debug_dumps"
 
+    @property
+    def data_dir(self) -> str:
+        """Directory for runtime data (gateway.db, attack_logs, etc.).
+
+        Resolution order:
+        1. Explicitly configured ``_data_dir`` value.
+        2. ``data/`` subdirectory next to the config file (if CONFIG_PATH
+           is set).
+        3. Empty string (let downstream code decide the default).
+        """
+        import os
+
+        if self._data_dir:
+            return self._data_dir
+        config_path = os.environ.get("CONFIG_PATH")
+        if config_path:
+            from pathlib import Path
+
+            return str(Path(config_path).parent / "data")
+        return ""
+
     @classmethod
     def from_dict(cls, config_dict: dict):
         """Create ArgoConfig instance from a dictionary."""
@@ -230,6 +254,7 @@ class ArgoConfig:
             "anthropic_stream_mode": "_anthropic_stream_mode",
             "dump_requests": "_dump_requests",
             "dump_dir": "_dump_dir",
+            "data_dir": "_data_dir",
         }
         valid_fields = {
             k: v for k, v in config_dict.items() if k in cls.__annotations__
@@ -269,6 +294,8 @@ class ArgoConfig:
             serialized["dump_requests"] = True
         if self._dump_dir:
             serialized["dump_dir"] = self._dump_dir
+        if self._data_dir:
+            serialized["data_dir"] = self._data_dir
 
         # Persist model refresh interval only when non-default
         if self.model_refresh_interval_hours == 24:

--- a/src/argoproxy/utils/attack_logger.py
+++ b/src/argoproxy/utils/attack_logger.py
@@ -96,13 +96,19 @@ class AttackLogger:
         """
         self.enabled = True
         self._log_dir: Path | None = None
+        self._data_dir: Path | None = None
         self._config_path = config_path
 
     @property
     def log_dir(self) -> Path:
-        """Get or create the attack log directory."""
+        """Get or create the attack log directory.
+
+        Resolution order: explicit data_dir > config file parent > cwd.
+        """
         if self._log_dir is None:
-            if self._config_path:
+            if self._data_dir:
+                base_dir = self._data_dir
+            elif self._config_path:
                 base_dir = self._config_path.parent
             else:
                 base_dir = Path.cwd()
@@ -119,6 +125,15 @@ class AttackLogger:
             config_path: New path to the config file.
         """
         self._config_path = config_path
+        self._log_dir = None  # Reset to recalculate on next access
+
+    def set_data_dir(self, data_dir: Path) -> None:
+        """Set an explicit data directory for attack logs.
+
+        Args:
+            data_dir: Directory where attack logs will be stored.
+        """
+        self._data_dir = data_dir
         self._log_dir = None  # Reset to recalculate on next access
 
     def classify_attack(self, raw_data: str) -> str:


### PR DESCRIPTION
## Summary

- Add `--data-dir` CLI flag to `serve` and `logs collect` subcommands
- Add `data_dir` config field to `ArgoConfig` (persisted in YAML when set)
- Pass `data_dir` through bridge → `GatewayConfig` → `setup_admin()` so llm-rosetta's `PersistenceManager` uses the correct directory
- Update `AttackLogger` to prefer `data_dir` over config-file-relative paths
- Update `_collect_diagnostic_logs` to resolve from `data_dir`

Resolution order: CLI `--data-dir` > config `data_dir` field > `data/` next to config file.

This enables profile-based deployments where config and runtime data live in separate directories (e.g. `profile_dev/config.yaml` + `profile_dev/data/`).

## Test plan

- [x] `ruff check` + `ruff format` + `ty check` pass (pre-commit hooks green)
- [x] Smoke tests: `ArgoConfig.from_dict` with/without `data_dir`, `to_persistent_dict` serialization, CLI parser `--data-dir`, `AttackLogger.set_data_dir`
- [ ] Manual test on ts-docker-build with `argo-proxy serve config.yaml --data-dir ./data`