### PR TITLE
fix: only rebuild counters when lagging behind log, not when ahead

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -857,12 +857,14 @@ async def _startup(app: App) -> None:
         },
     )
 
-    # Auto-rebuild counters if persisted total drifted from actual log entries
+    # Auto-rebuild if counters lag behind the log (ungraceful shutdown).
+    # Only rebuild when counters < log — the reverse (counters > log) is
+    # expected when log retention caps purge old entries.
     persistence = getattr(app, "persistence", None)
     metrics = getattr(app, "metrics", None)
     if persistence is not None and metrics is not None:
         log_entries = persistence.count_log_entries()
-        if metrics.total_requests != log_entries:
+        if metrics.total_requests < log_entries:
             log_warning(
                 f"Counter drift detected (counters={metrics.total_requests}, "
                 f"log={log_entries}), rebuilding from request log",


### PR DESCRIPTION
## Summary
- Change counter drift check from `!=` to `<` so we only rebuild when counters are behind the log (crash/ungraceful shutdown), not when ahead (normal behavior with log retention caps)
- Without this fix, every startup with active log caps would reset `total_requests` to the capped entry count, losing the real total

Follow-up to #167, same fix applied to llm-rosetta in Oaklight/llm-rosetta#643.

## Test plan
- [ ] Verify startup with `total_requests > log_entries` (caps active) does NOT trigger rebuild
- [ ] Verify startup with `total_requests < log_entries` (missed flush) DOES trigger rebuild